### PR TITLE
Remove eventpublishers and eventstreams from the tenant space of Identity Server

### DIFF
--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/NotificationHandler.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/NotificationHandler.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.identity.event.handler.notification;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.event.stream.core.EventStreamService;
 import org.wso2.carbon.identity.base.IdentityRuntimeException;
 import org.wso2.carbon.identity.core.handler.InitConfig;
@@ -32,6 +33,7 @@ import org.wso2.carbon.identity.event.handler.notification.email.bean.Notificati
 import org.wso2.carbon.identity.event.handler.notification.internal.NotificationHandlerDataHolder;
 import org.wso2.carbon.identity.event.handler.notification.util.NotificationUtil;
 import org.wso2.carbon.email.mgt.util.I18nEmailUtil;
+import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -69,7 +71,15 @@ public class NotificationHandler extends DefaultNotificationHandler {
         //This stream-id was set to the map to pass to the publishToStream method only to avoid API change.
         arbitraryDataMap.put("tmp-stream-id", streamDefinitionID);
 
-        publishToStream(notification, arbitraryDataMap);
+        try {
+            // Use the super tenant's EmailPublisher.xml and id_gov_notify_stream_1.0.0.json to publish the stream.
+            PrivilegedCarbonContext.startTenantFlow();
+            PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantId(MultitenantConstants.SUPER_TENANT_ID);
+            PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+            publishToStream(notification, arbitraryDataMap);
+        } finally {
+            PrivilegedCarbonContext.endTenantFlow();
+        }
     }
 
     protected void publishToStream(Notification notification, Map<String, String> placeHolderDataMap) {

--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/listener/NotificationEventTenantListener.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/listener/NotificationEventTenantListener.java
@@ -66,13 +66,7 @@ public class NotificationEventTenantListener implements TenantMgtListener {
         } catch (UserStoreException e) {
             throw new StratosException("Error in starting a tenant flow.", e);
         }
-        NotificationUtil.deployStream(NotificationConstants.EmailNotification.STREAM_NAME,
-                NotificationConstants.EmailNotification.STREAM_VERSION,
-                NotificationConstants.EmailNotification.STREAM_ID);
-        EventPublisherConfiguration eventPublisherConfig = getEventPublisherConfig();
-        NotificationUtil.deployPublisher(eventPublisherConfig);
         PrivilegedCarbonContext.endTenantFlow();
-
     }
 
     @Override


### PR DESCRIPTION

### Proposed changes in this pull request

Remove eventpublishers and eventstreams from the tenant space of Identity Server