### PR TITLE
Adding SMS notification templates to the registry on server startup and tenant creation

### DIFF
--- a/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/EmailTemplateManagerImpl.java
+++ b/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/EmailTemplateManagerImpl.java
@@ -435,7 +435,7 @@ public class EmailTemplateManagerImpl implements EmailTemplateManager, Notificat
      * @param displayName         Display name of the template
      * @param locale              Locale of the template
      * @return Template content
-     * @throws NotificationTemplateManagerException Error getting the template content
+     * @throws NotificationTemplateManagerException If an error occurred while getting the template content
      */
     private String[] getTemplateElements(Resource templateResource, String notificationChannel, String displayName,
             String locale) throws NotificationTemplateManagerException {
@@ -515,7 +515,7 @@ public class EmailTemplateManagerImpl implements EmailTemplateManager, Notificat
      *
      * @param notificationTemplate Notification template
      * @return Resource
-     * @throws NotificationTemplateManagerServerException Error while creating the resource
+     * @throws NotificationTemplateManagerServerException If an error occurred while creating the resource
      */
     private Resource createTemplateRegistryResource(NotificationTemplate notificationTemplate)
             throws NotificationTemplateManagerServerException {

--- a/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/EmailTemplateManagerImpl.java
+++ b/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/EmailTemplateManagerImpl.java
@@ -18,15 +18,17 @@ package org.wso2.carbon.email.mgt;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
+import org.apache.axiom.om.OMElement;
+import org.apache.axiom.om.impl.builder.StAXOMBuilder;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.email.mgt.constants.I18nMgtConstants;
+import org.wso2.carbon.email.mgt.exceptions.DuplicateEmailTemplateException;
 import org.wso2.carbon.email.mgt.exceptions.I18nEmailMgtClientException;
 import org.wso2.carbon.email.mgt.exceptions.I18nEmailMgtException;
 import org.wso2.carbon.email.mgt.exceptions.I18nEmailMgtInternalException;
 import org.wso2.carbon.email.mgt.exceptions.I18nEmailMgtServerException;
-import org.wso2.carbon.email.mgt.exceptions.DuplicateEmailTemplateException;
 import org.wso2.carbon.email.mgt.exceptions.I18nMgtEmailConfigException;
 import org.wso2.carbon.email.mgt.internal.I18nMgtDataHolder;
 import org.wso2.carbon.email.mgt.model.EmailTemplate;
@@ -38,17 +40,35 @@ import org.wso2.carbon.identity.governance.IdentityGovernanceUtil;
 import org.wso2.carbon.identity.governance.IdentityMgtConstants;
 import org.wso2.carbon.identity.governance.exceptions.notiification.NotificationTemplateManagerClientException;
 import org.wso2.carbon.identity.governance.exceptions.notiification.NotificationTemplateManagerException;
+import org.wso2.carbon.identity.governance.exceptions.notiification.NotificationTemplateManagerInternalException;
 import org.wso2.carbon.identity.governance.exceptions.notiification.NotificationTemplateManagerServerException;
 import org.wso2.carbon.identity.governance.model.NotificationTemplate;
 import org.wso2.carbon.identity.governance.service.notification.NotificationChannels;
 import org.wso2.carbon.identity.governance.service.notification.NotificationTemplateManager;
 import org.wso2.carbon.registry.core.Collection;
+import org.wso2.carbon.registry.core.RegistryConstants;
 import org.wso2.carbon.registry.core.Resource;
+import org.wso2.carbon.registry.core.ResourceImpl;
 import org.wso2.carbon.registry.core.exceptions.RegistryException;
+import org.wso2.carbon.utils.CarbonUtils;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+
+import javax.xml.namespace.QName;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
 
 import static org.wso2.carbon.email.mgt.constants.I18nMgtConstants.DEFAULT_EMAIL_LOCALE;
 import static org.wso2.carbon.email.mgt.constants.I18nMgtConstants.DEFAULT_SMS_NOTIFICATION_LOCALE;
@@ -56,7 +76,6 @@ import static org.wso2.carbon.email.mgt.constants.I18nMgtConstants.EMAIL_TEMPLAT
 import static org.wso2.carbon.email.mgt.constants.I18nMgtConstants.EMAIL_TEMPLATE_PATH;
 import static org.wso2.carbon.email.mgt.constants.I18nMgtConstants.EMAIL_TEMPLATE_TYPE_DISPLAY_NAME;
 import static org.wso2.carbon.email.mgt.constants.I18nMgtConstants.EMAIL_TEMPLATE_TYPE_REGEX;
-import static org.wso2.carbon.email.mgt.constants.I18nMgtConstants.ErrorMsg.DUPLICATE_TEMPLATE_TYPE;
 import static org.wso2.carbon.email.mgt.constants.I18nMgtConstants.SMS_TEMPLATE_PATH;
 import static org.wso2.carbon.identity.base.IdentityValidationUtil.ValidatorPattern.REGISTRY_INVALID_CHARS_EXISTS;
 import static org.wso2.carbon.registry.core.RegistryConstants.PATH_SEPARATOR;
@@ -83,26 +102,55 @@ public class EmailTemplateManagerImpl implements EmailTemplateManager, Notificat
     public void addEmailTemplateType(String emailTemplateDisplayName, String tenantDomain) throws
             I18nEmailMgtException {
 
-        validateTemplateType(emailTemplateDisplayName, tenantDomain);
-
-        // get template directory name from display name.
-        String normalizedTemplateName = I18nEmailUtil.getNormalizedName(emailTemplateDisplayName);
-
-        // persist the template type to registry ie. create a directory.
-        String path = EMAIL_TEMPLATE_PATH + PATH_SEPARATOR + normalizedTemplateName;
         try {
-            // check whether a template exists with the same name.
-            if (resourceMgtService.isResourceExists(path, tenantDomain)) {
-                String errorMsg = String.format(DUPLICATE_TEMPLATE_TYPE, emailTemplateDisplayName, tenantDomain);
-                throw new I18nEmailMgtInternalException(
-                        I18nMgtConstants.ErrorCodes.EMAIL_TEMPLATE_TYPE_ALREADY_EXISTS, errorMsg);
+            addNotificationTemplateType(emailTemplateDisplayName, NotificationChannels.EMAIL_CHANNEL.getChannelType(),
+                    tenantDomain);
+        } catch (NotificationTemplateManagerClientException e) {
+            throw new I18nEmailMgtClientException(e.getMessage(), e);
+        } catch (NotificationTemplateManagerInternalException e) {
+            if (StringUtils.isNotBlank(e.getErrorCode())) {
+                String errorCode = e.getErrorCode();
+                if (errorCode.contains(I18nMgtConstants.ErrorMessages.ERROR_CODE_DUPLICATE_TEMPLATE_TYPE.getCode())) {
+                    throw new I18nEmailMgtInternalException(
+                            I18nMgtConstants.ErrorCodes.EMAIL_TEMPLATE_TYPE_ALREADY_EXISTS, e.getMessage(), e);
+                }
             }
+            throw new I18nEmailMgtInternalException(e.getMessage(), e);
+        } catch (NotificationTemplateManagerException e) {
+            throw new I18nEmailMgtServerException(e.getMessage(), e);
+        }
+    }
 
-            Collection collection = I18nEmailUtil.createTemplateType(normalizedTemplateName, emailTemplateDisplayName);
+    @Override
+    public void addNotificationTemplateType(String displayName, String notificationChannel, String tenantDomain)
+            throws NotificationTemplateManagerException {
+
+        validateDisplayNameOfTemplateType(displayName);
+        String normalizedDisplayName = I18nEmailUtil.getNormalizedName(displayName);
+
+        // Persist the template type to registry ie. create a directory.
+        String path = buildTemplateRootDirectoryPath(normalizedDisplayName, notificationChannel);
+        try {
+            // Check whether a template exists with the same name.
+            if (resourceMgtService.isResourceExists(path, tenantDomain)) {
+                String code = I18nEmailUtil.prependOperationScenarioToErrorCode(
+                        I18nMgtConstants.ErrorMessages.ERROR_CODE_DUPLICATE_TEMPLATE_TYPE.getCode(),
+                        I18nMgtConstants.ErrorScenarios.EMAIL_TEMPLATE_MANAGER);
+                String message =
+                        String.format(I18nMgtConstants.ErrorMessages.ERROR_CODE_DUPLICATE_TEMPLATE_TYPE.getMessage(),
+                                displayName, tenantDomain);
+                throw new NotificationTemplateManagerInternalException(code, message);
+            }
+            Collection collection = I18nEmailUtil.createTemplateType(normalizedDisplayName, displayName);
             resourceMgtService.putIdentityResource(collection, path, tenantDomain);
         } catch (IdentityRuntimeException ex) {
-            String errorMsg = "Error adding template type %s to %s tenant.";
-            throw new I18nEmailMgtServerException(String.format(errorMsg, emailTemplateDisplayName, tenantDomain), ex);
+            String code = I18nEmailUtil.prependOperationScenarioToErrorCode(
+                    I18nMgtConstants.ErrorMessages.ERROR_CODE_ERROR_ADDING_TEMPLATE.getCode(),
+                    I18nMgtConstants.ErrorScenarios.EMAIL_TEMPLATE_MANAGER);
+            String message =
+                    String.format(I18nMgtConstants.ErrorMessages.ERROR_CODE_ERROR_ADDING_TEMPLATE.getMessage(),
+                            displayName, tenantDomain);
+            throw new NotificationTemplateManagerServerException(code, message);
         }
     }
 
@@ -191,8 +239,13 @@ public class EmailTemplateManagerImpl implements EmailTemplateManager, Notificat
             if (StringUtils.isNotEmpty(exception.getErrorCode())) {
                 if (IdentityMgtConstants.ErrorMessages.ERROR_CODE_INVALID_NOTIFICATION_TEMPLATE.getCode()
                         .equals(errorCode) || IdentityMgtConstants.ErrorMessages.ERROR_CODE_NO_CONTENT_IN_TEMPLATE
-                        .getCode().equals(errorCode)) {
+                        .getCode().equals(errorCode) ||
+                        I18nMgtConstants.ErrorMessages.ERROR_CODE_INVALID_CHARACTERS_IN_TEMPLATE_NAME.getCode()
+                                .equals(errorCode) ||
+                        I18nMgtConstants.ErrorMessages.ERROR_CODE_INVALID_CHARACTERS_IN_LOCALE
+                                .getCode().equals(errorCode)) {
                     throw new I18nEmailMgtClientException(errorMsg, throwable);
+
                 } else if (IdentityMgtConstants.ErrorMessages.ERROR_CODE_INVALID_EMAIL_TEMPLATE_CONTENT.getCode()
                         .equals(errorCode)) {
                     throw new I18nMgtEmailConfigException(errorMsg, throwable);
@@ -275,7 +328,8 @@ public class EmailTemplateManagerImpl implements EmailTemplateManager, Notificat
 
         // Resolve channel to either SMS or EMAIL.
         notificationChannel = resolveNotificationChannel(notificationChannel);
-        validateTemplate(templateType, locale, tenantDomain);
+        validateTemplateLocale(locale);
+        validateDisplayNameOfTemplateType(templateType);
         NotificationTemplate notificationTemplate = null;
 
         // Get notification template registry path.
@@ -434,27 +488,6 @@ public class EmailTemplateManagerImpl implements EmailTemplateManager, Notificat
     }
 
     /**
-     * Validate template type.
-     *
-     * @param templateType Template type
-     * @param locale       Locale
-     * @param tenantDomain Tenant domain
-     * @throws NotificationTemplateManagerClientException Invalid notification template.
-     */
-    private void validateTemplate(String templateType, String locale, String tenantDomain)
-            throws NotificationTemplateManagerClientException {
-
-        try {
-            validateTemplateType(templateType, tenantDomain);
-            validateLocale(locale);
-        } catch (I18nEmailMgtException exception) {
-            throw new NotificationTemplateManagerClientException(
-                    IdentityMgtConstants.ErrorMessages.ERROR_CODE_INVALID_NOTIFICATION_TEMPLATE.getCode(),
-                    exception.getMessage(), exception);
-        }
-    }
-
-    /**
      * Resolve notification channel to a server supported notification channel.
      *
      * @param notificationChannel Notification channel
@@ -477,33 +510,107 @@ public class EmailTemplateManagerImpl implements EmailTemplateManager, Notificat
         }
     }
 
+    /**
+     * Create a registry resource instance of the notification template.
+     *
+     * @param notificationTemplate Notification template
+     * @return Resource
+     * @throws NotificationTemplateManagerServerException
+     */
+    private Resource createTemplateRegistryResource(NotificationTemplate notificationTemplate)
+            throws NotificationTemplateManagerServerException {
+
+        String displayName = notificationTemplate.getDisplayName();
+        String type = I18nEmailUtil.getNormalizedName(displayName);
+        String locale = notificationTemplate.getLocale();
+        String body = notificationTemplate.getBody();
+
+        // Set template properties.
+        Resource templateResource = new ResourceImpl();
+        templateResource.setProperty(I18nMgtConstants.TEMPLATE_TYPE_DISPLAY_NAME, displayName);
+        templateResource.setProperty(I18nMgtConstants.TEMPLATE_TYPE, type);
+        templateResource.setProperty(I18nMgtConstants.TEMPLATE_LOCALE, locale);
+        String[] templateContent;
+        // Handle contents according to different channel types.
+        if (NotificationChannels.EMAIL_CHANNEL.getChannelType().equals(notificationTemplate.getNotificationChannel())) {
+            templateContent = new String[]{notificationTemplate.getSubject(), body, notificationTemplate.getFooter()};
+            templateResource.setProperty(I18nMgtConstants.TEMPLATE_CONTENT_TYPE, notificationTemplate.getContentType());
+        } else {
+            templateContent = new String[]{body};
+        }
+        templateResource.setMediaType(RegistryConstants.TAG_MEDIA_TYPE);
+        String content = new Gson().toJson(templateContent);
+        try {
+            byte[] contentByteArray = content.getBytes(StandardCharsets.UTF_8);
+            templateResource.setContent(contentByteArray);
+        } catch (RegistryException e) {
+            String code =
+                    I18nEmailUtil.prependOperationScenarioToErrorCode(
+                            I18nMgtConstants.ErrorMessages.ERROR_CODE_ERROR_CREATING_REGISTRY_RESOURCE.getCode(),
+                            I18nMgtConstants.ErrorScenarios.EMAIL_TEMPLATE_MANAGER);
+            String message =
+                    String.format(
+                            I18nMgtConstants.ErrorMessages.ERROR_CODE_ERROR_CREATING_REGISTRY_RESOURCE.getMessage(),
+                            displayName, locale);
+            throw new NotificationTemplateManagerServerException(code, message, e);
+        }
+        return templateResource;
+    }
+
+    @Override
+    public void addNotificationTemplate(NotificationTemplate notificationTemplate, String tenantDomain)
+            throws NotificationTemplateManagerException {
+
+        String notificationChannel = notificationTemplate.getNotificationChannel();
+        validateNotificationTemplate(notificationTemplate);
+
+        Resource templateResource = createTemplateRegistryResource(notificationTemplate);
+        String displayName = notificationTemplate.getDisplayName();
+        String type = I18nEmailUtil.getNormalizedName(displayName);
+        String locale = notificationTemplate.getLocale();
+
+        String path = buildTemplateRootDirectoryPath(type, notificationChannel);
+        try {
+            // Check whether a template type root directory exists.
+            if (!resourceMgtService.isResourceExists(path, tenantDomain)) {
+                // Add new template type with relevant properties.
+                addNotificationTemplateType(displayName, notificationChannel, tenantDomain);
+                if (log.isDebugEnabled()) {
+                    String msg = "Creating template type : %s in tenant registry : %s";
+                    log.debug(String.format(msg, displayName, tenantDomain));
+                }
+            }
+            resourceMgtService.putIdentityResource(templateResource, path, tenantDomain, locale);
+        } catch (IdentityRuntimeException e) {
+            String code = I18nEmailUtil.prependOperationScenarioToErrorCode(
+                    I18nMgtConstants.ErrorMessages.ERROR_CODE_ERROR_ERROR_ADDING_TEMPLATE.getCode(),
+                    I18nMgtConstants.ErrorScenarios.EMAIL_TEMPLATE_MANAGER);
+            String message =
+                    String.format(I18nMgtConstants.ErrorMessages.ERROR_CODE_ERROR_ERROR_ADDING_TEMPLATE.getMessage(),
+                            displayName, locale, tenantDomain);
+            throw new NotificationTemplateManagerServerException(code, message);
+        }
+    }
+
     @Override
     public void addEmailTemplate(EmailTemplate emailTemplate, String tenantDomain) throws I18nEmailMgtException {
 
-        // validate the email template object before processing it.
-        validateEmailTemplate(emailTemplate, tenantDomain);
-
-        Resource templateResource = I18nEmailUtil.createTemplateResource(emailTemplate);
-        String templateTypeDisplayName = emailTemplate.getTemplateDisplayName();
-        String templateType = I18nEmailUtil.getNormalizedName(templateTypeDisplayName);
-        String locale = emailTemplate.getLocale();
-
-        String path = EMAIL_TEMPLATE_PATH + PATH_SEPARATOR + templateType; // template type root directory
+        NotificationTemplate notificationTemplate = buildNotificationTemplateFromEmailTemplate(emailTemplate);
         try {
-            // check whether a template type root directory exists
-            if (!resourceMgtService.isResourceExists(path, tenantDomain)) {
-                // we add new template type with relevant properties
-                addEmailTemplateType(templateTypeDisplayName, tenantDomain);
-                if (log.isDebugEnabled()) {
-                    String msg = "Creating template type %s in %s tenant registry.";
-                    log.debug(String.format(msg, templateTypeDisplayName, tenantDomain));
+            addNotificationTemplate(notificationTemplate, tenantDomain);
+        } catch (NotificationTemplateManagerClientException e) {
+            throw new I18nEmailMgtClientException(e.getMessage(), e);
+        } catch (NotificationTemplateManagerInternalException e) {
+            if (StringUtils.isNotBlank(e.getErrorCode())) {
+                String errorCode = e.getErrorCode();
+                if (errorCode.contains(I18nMgtConstants.ErrorMessages.ERROR_CODE_DUPLICATE_TEMPLATE_TYPE.getCode())) {
+                    throw new I18nEmailMgtInternalException(
+                            I18nMgtConstants.ErrorCodes.EMAIL_TEMPLATE_TYPE_ALREADY_EXISTS, e.getMessage(), e);
                 }
             }
-
-            resourceMgtService.putIdentityResource(templateResource, path, tenantDomain, locale);
-        } catch (IdentityRuntimeException ex) {
-            String errorMsg = "Error when adding new email template of %s type, %s locale to %s tenant registry.";
-            handleServerException(String.format(errorMsg, templateResource, locale, tenantDomain), ex);
+            throw new I18nEmailMgtInternalException(e.getMessage(), e);
+        } catch (NotificationTemplateManagerException e) {
+            throw new I18nEmailMgtServerException(e.getMessage(), e);
         }
     }
 
@@ -534,6 +641,24 @@ public class EmailTemplateManagerImpl implements EmailTemplateManager, Notificat
 
     @Override
     public void addDefaultEmailTemplates(String tenantDomain) throws I18nEmailMgtException {
+
+        try {
+            addDefaultNotificationTemplates(NotificationChannels.EMAIL_CHANNEL.getChannelType(), tenantDomain);
+        } catch (NotificationTemplateManagerClientException e) {
+            throw new I18nEmailMgtClientException(e.getMessage(), e);
+        } catch (NotificationTemplateManagerInternalException e) {
+            if (StringUtils.isNotBlank(e.getErrorCode())) {
+                String errorCode = e.getErrorCode();
+                if (errorCode.contains(I18nMgtConstants.ErrorMessages.ERROR_CODE_DUPLICATE_TEMPLATE_TYPE.getCode())) {
+                    throw new I18nEmailMgtInternalException(
+                            I18nMgtConstants.ErrorCodes.EMAIL_TEMPLATE_TYPE_ALREADY_EXISTS, e.getMessage(), e);
+                }
+            }
+            throw new I18nEmailMgtInternalException(e.getMessage(), e);
+        } catch (NotificationTemplateManagerException e) {
+            throw new I18nEmailMgtServerException(e.getMessage(), e);
+        }
+
 
         try {
             // load DTOs from the I18nEmailUtil class
@@ -569,6 +694,162 @@ public class EmailTemplateManagerImpl implements EmailTemplateManager, Notificat
             String error = "Error when tried to check for default email templates in %s tenant registry";
             log.error(String.format(error, tenantDomain), ex);
         }
+    }
+
+    /**
+     * Add the default notification templates which matches the given notification channel to the respective tenants
+     * registry.
+     *
+     * @param notificationChannel Notification channel (Eg: SMS, EMAIL)
+     * @param tenantDomain Tenant domain
+     * @throws NotificationTemplateManagerException Error adding the default notification templates
+     */
+    @Override
+    public void addDefaultNotificationTemplates(String notificationChannel, String tenantDomain)
+            throws NotificationTemplateManagerException {
+
+        // Get the list of Default notification templates.
+        List<NotificationTemplate> notificationTemplates =
+                getDefaultNotificationTemplates(notificationChannel);
+        int numberOfAddedTemplates = 0;
+        try {
+            for (NotificationTemplate template : notificationTemplates) {
+                String displayName = template.getDisplayName();
+                String type = I18nEmailUtil.getNormalizedName(displayName);
+                String path = buildTemplateRootDirectoryPath(type, notificationChannel);
+
+            /*Check for existence of each category, since some template may have migrated from earlier version
+            This will also add new template types provided from file, but won't update any existing template*/
+                if (!resourceMgtService.isResourceExists(path, tenantDomain)) {
+                    try {
+                        addNotificationTemplate(template, tenantDomain);
+                        if (log.isDebugEnabled()) {
+                            String msg = "Default template added to %s tenant registry : %n%s";
+                            log.debug(String.format(msg, tenantDomain, template.toString()));
+                        }
+                        numberOfAddedTemplates++;
+                    } catch (NotificationTemplateManagerInternalException e) {
+                        log.warn("Template : " + displayName + "already exists in the registry. Hence " +
+                                "ignoring addition");
+                    }
+                }
+            }
+            if (log.isDebugEnabled()) {
+                log.debug(String.format("Added %d default %s templates to the tenant registry : %s",
+                        numberOfAddedTemplates, notificationChannel, tenantDomain));
+            }
+        } catch (IdentityRuntimeException ex) {
+            String error = "Error when tried to check for default email templates in tenant registry : %s";
+            log.error(String.format(error, tenantDomain), ex);
+        }
+    }
+
+    /**
+     * Get the notification templates which matches the given notification template type.
+     *
+     * @param notificationChannel Notification channel type. (Eg: EMAIL, SMS)
+     * @return List of default notification templates
+     */
+    @Override
+    public List<NotificationTemplate> getDefaultNotificationTemplates(String notificationChannel) {
+
+        String configFilePath = buildNotificationTemplateConfigPath(notificationChannel);
+        File configFile = new File(configFilePath);
+        if (!configFile.exists()) {
+            log.error("Email Configuration File is not present at: " + configFilePath);
+        }
+
+        List<NotificationTemplate> defaultNotificationTemplates = new ArrayList<>();
+        XMLStreamReader xmlStreamReader = null;
+        InputStream inputStream = null;
+
+        try {
+            inputStream = new FileInputStream(configFile);
+            xmlStreamReader = XMLInputFactory.newInstance().createXMLStreamReader(inputStream);
+            StAXOMBuilder builder = new StAXOMBuilder(xmlStreamReader);
+
+            OMElement documentElement = builder.getDocumentElement();
+            Iterator iterator = documentElement.getChildElements();
+            while (iterator.hasNext()) {
+                OMElement omElement = (OMElement) iterator.next();
+                Map<String, String> templateContentMap = getNotificationTemplateContent(omElement);
+
+                // Create notification template model with the template attributes.
+                NotificationTemplate notificationTemplate = new NotificationTemplate();
+                notificationTemplate.setType(omElement.getAttributeValue(new QName(I18nMgtConstants.TEMPLATE_TYPE)));
+                notificationTemplate.setDisplayName(
+                        omElement.getAttributeValue(new QName(I18nMgtConstants.TEMPLATE_TYPE_DISPLAY_NAME)));
+                notificationTemplate
+                        .setLocale(omElement.getAttributeValue(new QName(I18nMgtConstants.TEMPLATE_LOCALE)));
+                notificationTemplate.setBody(templateContentMap.get(I18nMgtConstants.TEMPLATE_BODY));
+                notificationTemplate.setNotificationChannel(notificationChannel);
+
+                if (NotificationChannels.EMAIL_CHANNEL.getChannelType().equals(notificationChannel)) {
+                    notificationTemplate.setContentType(
+                            omElement.getAttributeValue(new QName(I18nMgtConstants.TEMPLATE_CONTENT_TYPE)));
+                    notificationTemplate.setFooter(templateContentMap.get(I18nMgtConstants.TEMPLATE_FOOTER));
+                    notificationTemplate.setSubject(templateContentMap.get(I18nMgtConstants.TEMPLATE_SUBJECT));
+                }
+                defaultNotificationTemplates.add(notificationTemplate);
+            }
+        } catch (XMLStreamException | FileNotFoundException e) {
+            log.warn("Error while loading default templates to the registry.", e);
+        } finally {
+            try {
+                if (xmlStreamReader != null) {
+                    xmlStreamReader.close();
+                }
+                if (inputStream != null) {
+                    inputStream.close();
+                }
+            } catch (XMLStreamException e) {
+                log.error("Error while closing XML stream", e);
+            } catch (IOException e) {
+                log.error("Error while closing input stream", e);
+            }
+        }
+        return defaultNotificationTemplates;
+    }
+
+    /**
+     * Get the template attributes of the notification template such as SUBJECT, BODY, EMAIL.
+     *
+     * @param templateElement OMElement
+     * @return List of attributes in the notification template
+     */
+    private static Map<String, String> getNotificationTemplateContent(OMElement templateElement) {
+
+        Map<String, String> notificationTemplateContent = new HashMap<>();
+        Iterator it = templateElement.getChildElements();
+        while (it.hasNext()) {
+            OMElement element = (OMElement) it.next();
+            String elementName = element.getLocalName();
+            String elementText = element.getText();
+            if (StringUtils.equalsIgnoreCase(I18nMgtConstants.TEMPLATE_SUBJECT, elementName)) {
+                notificationTemplateContent.put(I18nMgtConstants.TEMPLATE_SUBJECT, elementText);
+            } else if (StringUtils.equalsIgnoreCase(I18nMgtConstants.TEMPLATE_BODY, elementName)) {
+                notificationTemplateContent.put(I18nMgtConstants.TEMPLATE_BODY, elementText);
+            } else if (StringUtils.equalsIgnoreCase(I18nMgtConstants.TEMPLATE_FOOTER, elementName)) {
+                notificationTemplateContent.put(I18nMgtConstants.TEMPLATE_FOOTER, elementText);
+            }
+        }
+        return notificationTemplateContent;
+    }
+
+    /**
+     * Build the file path of the notification template config file according to the given channel.
+     *
+     * @param notificationChannel Notification channel name (EMAIL,SMS)
+     * @return Path of the configuration file
+     */
+    private String buildNotificationTemplateConfigPath(String notificationChannel) {
+
+        if (NotificationChannels.SMS_CHANNEL.getChannelType().equals(notificationChannel)) {
+            return CarbonUtils.getCarbonConfigDirPath() + File.separator +
+                    I18nMgtConstants.SMS_CONF_DIRECTORY + File.separator + I18nMgtConstants.SMS_TEMPLAE_ADMIN_CONF_FILE;
+        }
+        return CarbonUtils.getCarbonConfigDirPath() + File.separator +
+                I18nMgtConstants.EMAIL_CONF_DIRECTORY + File.separator + I18nMgtConstants.EMAIL_ADMIN_CONF_FILE;
     }
 
     @Override
@@ -607,37 +888,57 @@ public class EmailTemplateManagerImpl implements EmailTemplateManager, Notificat
     }
 
     /**
-     * Validate an EmailTemplate object before persisting it into tenant's registry.
+     * Validate the attributes of a notification template.
      *
-     * @param emailTemplate
+     * @param notificationTemplate Notification template
+     * @throws NotificationTemplateManagerClientException Invalid notification template.
      */
-    private void validateEmailTemplate(EmailTemplate emailTemplate, String tenantDomain) throws
-            I18nEmailMgtClientException {
+    private void validateNotificationTemplate(NotificationTemplate notificationTemplate)
+            throws NotificationTemplateManagerClientException {
 
-        if (emailTemplate == null) {
-            throw new I18nEmailMgtClientException("Email Template object cannot be null.");
+        if (notificationTemplate == null) {
+            String errorCode =
+                    I18nEmailUtil.prependOperationScenarioToErrorCode(
+                            I18nMgtConstants.ErrorMessages.ERROR_CODE_NULL_TEMPLATE_OBJECT.getCode(),
+                            I18nMgtConstants.ErrorScenarios.EMAIL_TEMPLATE_MANAGER);
+            throw new NotificationTemplateManagerClientException(errorCode,
+                    I18nMgtConstants.ErrorMessages.ERROR_CODE_NULL_TEMPLATE_OBJECT.getMessage());
         }
-
-        String templateDisplayName = emailTemplate.getTemplateDisplayName();
-        validateTemplateType(templateDisplayName, tenantDomain);
-
-        String normalizedTemplateDisplayName = I18nEmailUtil.getNormalizedName(templateDisplayName);
-        if (!StringUtils.equalsIgnoreCase(normalizedTemplateDisplayName, emailTemplate.getTemplateType())) {
-            emailTemplate.setTemplateType(normalizedTemplateDisplayName);
+        String displayName = notificationTemplate.getDisplayName();
+        validateDisplayNameOfTemplateType(displayName);
+        String normalizedDisplayName = I18nEmailUtil.getNormalizedName(displayName);
+        if (!StringUtils.equalsIgnoreCase(normalizedDisplayName, notificationTemplate.getType())) {
+            if (log.isDebugEnabled()) {
+                String message = String.format("In the template normalizedDisplayName : %s is not equal to the " +
+                                "template type : %s. Therefore template type is sent to : %s", normalizedDisplayName,
+                        notificationTemplate.getType(), normalizedDisplayName);
+                log.debug(message);
+            }
+            notificationTemplate.setType(normalizedDisplayName);
         }
-
-        String locale = emailTemplate.getLocale();
-        validateLocale(locale);
-
-        // TODO validate content type?
-        String subject = emailTemplate.getSubject();
-        String body = emailTemplate.getBody();
-        String footer = emailTemplate.getFooter();
-
-        if (StringUtils.isBlank(subject) || StringUtils.isBlank(body) || StringUtils.isBlank(footer)) {
-            throw new I18nEmailMgtClientException("subject/body/footer sections of email template cannot be empty.");
+        validateTemplateLocale(notificationTemplate.getLocale());
+        String body = notificationTemplate.getBody();
+        if (NotificationChannels.SMS_CHANNEL.getChannelType().equals(notificationTemplate.getNotificationChannel())) {
+            if (StringUtils.isBlank(body)) {
+                String errorCode =
+                        I18nEmailUtil.prependOperationScenarioToErrorCode(
+                                I18nMgtConstants.ErrorMessages.ERROR_CODE_INVALID_SMS_TEMPLATE.getCode(),
+                                I18nMgtConstants.ErrorScenarios.EMAIL_TEMPLATE_MANAGER);
+                throw new NotificationTemplateManagerClientException(errorCode,
+                        I18nMgtConstants.ErrorMessages.ERROR_CODE_INVALID_SMS_TEMPLATE.getMessage());
+            }
+        } else {
+            String subject = notificationTemplate.getSubject();
+            String footer = notificationTemplate.getFooter();
+            if (StringUtils.isBlank(subject) || StringUtils.isBlank(body) || StringUtils.isBlank(footer)) {
+                String errorCode =
+                        I18nEmailUtil.prependOperationScenarioToErrorCode(
+                                I18nMgtConstants.ErrorMessages.ERROR_CODE_INVALID_EMAIL_TEMPLATE.getCode(),
+                                I18nMgtConstants.ErrorScenarios.EMAIL_TEMPLATE_MANAGER);
+                throw new NotificationTemplateManagerClientException(errorCode,
+                        I18nMgtConstants.ErrorMessages.ERROR_CODE_INVALID_EMAIL_TEMPLATE.getMessage());
+            }
         }
-
     }
 
     /**
@@ -649,18 +950,20 @@ public class EmailTemplateManagerImpl implements EmailTemplateManager, Notificat
     private void validateTemplateType(String templateDisplayName, String tenantDomain)
             throws I18nEmailMgtClientException {
 
-        // Check for null or empty.
-        if (StringUtils.isBlank(templateDisplayName)) {
-            throw new I18nEmailMgtClientException(" Template Type displayname cannot be null.");
-        }
-
-        // Template name can contain only alphanumeric characters and spaces, it can't contain registry invalid
-        // characters.
-        String[] whiteListPatterns = { TEMPLATE_REGEX_KEY };
-        String[] blackListPatterns = { REGISTRY_INVALID_CHARS };
-        if (!IdentityValidationUtil.isValid(templateDisplayName, whiteListPatterns, blackListPatterns)) {
-            throw new I18nEmailMgtClientException(
-                    "Invalid characters exists in the email template display name : " + templateDisplayName);
+        try {
+            validateDisplayNameOfTemplateType(templateDisplayName);
+        } catch (NotificationTemplateManagerClientException e) {
+            if (StringUtils.isNotBlank(e.getErrorCode())) {
+                String errorCode = e.getErrorCode();
+                if (errorCode.contains(I18nMgtConstants.ErrorMessages.ERROR_CODE_EMPTY_TEMPLATE_NAME.getCode())) {
+                    throw new I18nEmailMgtClientException("Template Type display name cannot be null", e);
+                }
+                if (errorCode.contains(
+                        I18nMgtConstants.ErrorMessages.ERROR_CODE_INVALID_CHARACTERS_IN_TEMPLATE_NAME.getCode())) {
+                    throw new I18nEmailMgtClientException(e.getMessage(), e);
+                }
+            }
+            throw new I18nEmailMgtClientException("Invalid notification template", e);
         }
     }
 
@@ -696,27 +999,107 @@ public class EmailTemplateManagerImpl implements EmailTemplateManager, Notificat
         return templateList;
     }
 
-    /**
-     * Validates the locale of a template
-     *
-     * @param localeCode Locale
-     * @throws I18nEmailMgtClientException Invalid template locale
-     */
-    private void validateLocale(String localeCode) throws I18nEmailMgtClientException {
-
-        if (StringUtils.isBlank(localeCode)) {
-            throw new I18nEmailMgtClientException("Locale code cannot be empty or null");
-        }
-
-        // Regex check for registry invalid chars.
-        if (!IdentityValidationUtil.isValidOverBlackListPatterns(localeCode, REGISTRY_INVALID_CHARS)) {
-            throw new I18nEmailMgtClientException("Locale string contains invalid characters : " + localeCode);
-        }
-    }
-
     private void handleServerException(String errorMsg, Throwable ex) throws I18nEmailMgtServerException {
 
         log.error(errorMsg);
         throw new I18nEmailMgtServerException(errorMsg, ex);
+    }
+
+    /**
+     * Validate the display name of the notification template.
+     *
+     * @param displayName Display name
+     * @throws NotificationTemplateManagerClientException Invalid notification template name
+     */
+    private void validateDisplayNameOfTemplateType(String displayName)
+            throws NotificationTemplateManagerClientException {
+
+        if (StringUtils.isBlank(displayName)) {
+            String errorCode =
+                    I18nEmailUtil.prependOperationScenarioToErrorCode(
+                            I18nMgtConstants.ErrorMessages.ERROR_CODE_EMPTY_TEMPLATE_NAME.getCode(),
+                            I18nMgtConstants.ErrorScenarios.EMAIL_TEMPLATE_MANAGER);
+            throw new NotificationTemplateManagerClientException(errorCode,
+                    I18nMgtConstants.ErrorMessages.ERROR_CODE_EMPTY_TEMPLATE_NAME.getMessage());
+        }
+        /*Template name can contain only alphanumeric characters and spaces, it can't contain registry invalid
+        characters*/
+        String[] whiteListPatterns = {TEMPLATE_REGEX_KEY};
+        String[] blackListPatterns = {REGISTRY_INVALID_CHARS};
+        if (!IdentityValidationUtil.isValid(displayName, whiteListPatterns, blackListPatterns)) {
+            String errorCode =
+                    I18nEmailUtil.prependOperationScenarioToErrorCode(
+                            I18nMgtConstants.ErrorMessages.ERROR_CODE_INVALID_CHARACTERS_IN_TEMPLATE_NAME.getCode(),
+                            I18nMgtConstants.ErrorScenarios.EMAIL_TEMPLATE_MANAGER);
+            String message =
+                    String.format(
+                            I18nMgtConstants.ErrorMessages.ERROR_CODE_INVALID_CHARACTERS_IN_TEMPLATE_NAME.getMessage(),
+                            displayName);
+            throw new NotificationTemplateManagerClientException(errorCode, message);
+        }
+    }
+
+    /**
+     * Validates the locale code of a notification template.
+     *
+     * @param locale Locale code
+     * @throws NotificationTemplateManagerClientException Invalid notification template
+     */
+    private void validateTemplateLocale(String locale) throws NotificationTemplateManagerClientException {
+
+        if (StringUtils.isBlank(locale)) {
+            String errorCode =
+                    I18nEmailUtil.prependOperationScenarioToErrorCode(
+                            I18nMgtConstants.ErrorMessages.ERROR_CODE_EMPTY_LOCALE.getCode(),
+                            I18nMgtConstants.ErrorScenarios.EMAIL_TEMPLATE_MANAGER);
+            throw new NotificationTemplateManagerClientException(errorCode,
+                    I18nMgtConstants.ErrorMessages.ERROR_CODE_EMPTY_LOCALE.getMessage());
+        }
+        // Regex check for registry invalid chars.
+        if (!IdentityValidationUtil.isValidOverBlackListPatterns(locale, REGISTRY_INVALID_CHARS)) {
+            String errorCode =
+                    I18nEmailUtil.prependOperationScenarioToErrorCode(
+                            I18nMgtConstants.ErrorMessages.ERROR_CODE_INVALID_CHARACTERS_IN_LOCALE.getCode(),
+                            I18nMgtConstants.ErrorScenarios.EMAIL_TEMPLATE_MANAGER);
+            String message =
+                    String.format(I18nMgtConstants.ErrorMessages.ERROR_CODE_INVALID_CHARACTERS_IN_LOCALE.getMessage(),
+                            locale);
+            throw new NotificationTemplateManagerClientException(errorCode, message);
+        }
+    }
+
+    /**
+     * Build the template type root directory path.
+     *
+     * @param type                Template type
+     * @param notificationChannel Notification channel (SMS or EMAIL)
+     * @return Root directory path
+     */
+    private String buildTemplateRootDirectoryPath(String type, String notificationChannel) {
+
+        if (NotificationChannels.SMS_CHANNEL.getChannelType().equals(notificationChannel)) {
+            return SMS_TEMPLATE_PATH + PATH_SEPARATOR + type;
+        }
+        return EMAIL_TEMPLATE_PATH + PATH_SEPARATOR + type;
+    }
+
+    /**
+     * Build notification template model from the email template attributes.
+     *
+     * @param emailTemplate EmailTemplate
+     * @return NotificationTemplate
+     */
+    private NotificationTemplate buildNotificationTemplateFromEmailTemplate(EmailTemplate emailTemplate) {
+
+        NotificationTemplate notificationTemplate = new NotificationTemplate();
+        notificationTemplate.setNotificationChannel(NotificationChannels.EMAIL_CHANNEL.getChannelType());
+        notificationTemplate.setSubject(emailTemplate.getSubject());
+        notificationTemplate.setBody(emailTemplate.getBody());
+        notificationTemplate.setFooter(emailTemplate.getFooter());
+        notificationTemplate.setType(emailTemplate.getTemplateType());
+        notificationTemplate.setDisplayName(emailTemplate.getTemplateDisplayName());
+        notificationTemplate.setLocale(emailTemplate.getLocale());
+        notificationTemplate.setContentType(emailTemplate.getEmailContentType());
+        return notificationTemplate;
     }
 }

--- a/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/constants/I18nMgtConstants.java
+++ b/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/constants/I18nMgtConstants.java
@@ -28,7 +28,9 @@ public class I18nMgtConstants {
     public static final String EMAIL_TEMPLATE_PATH = "/identity/email";
     public static final String SMS_TEMPLATE_PATH = "/identity/sms";
     public static final String EMAIL_CONF_DIRECTORY = "email";
+    public static final String SMS_CONF_DIRECTORY = "sms";
     public static final String EMAIL_ADMIN_CONF_FILE = "email-admin-config.xml";
+    public static final String SMS_TEMPLAE_ADMIN_CONF_FILE = "sms-templates-admin-config.xml";
     public static final String DEFAULT_EMAIL_LOCALE = "en_us";
     public static final String DEFAULT_SMS_NOTIFICATION_LOCALE = "en_us";
 
@@ -46,6 +48,7 @@ public class I18nMgtConstants {
     public static final String TEMPLATE_FOOTER = "footer";
 
     public static final String EMAIL_TEMPLATE_TYPE_REGEX = "[a-zA-Z0-9\\s]+";
+    public static final String ERROR_CODE_DELIMITER = "-";
 
     public static class ErrorMsg {
         private ErrorMsg() {
@@ -60,5 +63,61 @@ public class I18nMgtConstants {
 
         public static final String EMAIL_TEMPLATE_TYPE_NODE_FOUND = "10001";
         public static final String EMAIL_TEMPLATE_TYPE_ALREADY_EXISTS = "10002";
+    }
+
+    /**
+     * Class which contains the error scenarios.
+     */
+    public static class ErrorScenarios {
+
+        // ETM - EMAIL TEMPLATE MANAGER
+        public static final String EMAIL_TEMPLATE_MANAGER = "ETM";
+    }
+
+    /**
+     * Enum which contains error codes and corresponding error messages.
+     */
+    public enum ErrorMessages {
+
+        ERROR_CODE_NULL_TEMPLATE_OBJECT("60001", "Notification template object cannot be null."),
+        ERROR_CODE_EMPTY_TEMPLATE_NAME("60002", "Notification template name cannot be empty."),
+        ERROR_CODE_INVALID_CHARACTERS_IN_TEMPLATE_NAME("60003", "Invalid characters exists in the " +
+                "notification template display name : %s"),
+        ERROR_CODE_EMPTY_LOCALE("60004", "Locale code cannot be empty"),
+        ERROR_CODE_INVALID_CHARACTERS_IN_LOCALE("60005", "Locale contains invalid characters : %s"),
+        ERROR_CODE_INVALID_EMAIL_TEMPLATE("60006", "Subject/Body/Footer sections of an email template " +
+                "cannot be empty."),
+        ERROR_CODE_INVALID_SMS_TEMPLATE("60007", "Body of a SMS template cannot be empty."),
+        ERROR_CODE_DUPLICATE_TEMPLATE_TYPE("60008", "Notification template type : %s already exists " +
+                "in tenant registry: %s"),
+        ERROR_CODE_ERROR_CREATING_REGISTRY_RESOURCE("65001", "Error creating a registry resource " +
+                "from template : %s in locale : %s"),
+        ERROR_CODE_ERROR_ADDING_TEMPLATE("65002", "Error when adding template : %s to tenant : %s"),
+        ERROR_CODE_ERROR_ERROR_ADDING_TEMPLATE("65003", "Error when adding notification template " +
+                "of type : %s, in locale : %s to the tenant registry :  %s");
+        private final String code;
+        private final String message;
+
+        ErrorMessages(String code, String message) {
+
+            this.code = code;
+            this.message = message;
+        }
+
+        public String getCode() {
+
+            return code;
+        }
+
+        public String getMessage() {
+
+            return message;
+        }
+
+        @Override
+        public String toString() {
+
+            return code + " - " + message;
+        }
     }
 }

--- a/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/constants/I18nMgtConstants.java
+++ b/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/constants/I18nMgtConstants.java
@@ -90,6 +90,8 @@ public class I18nMgtConstants {
         ERROR_CODE_INVALID_SMS_TEMPLATE("60007", "Body of a SMS template cannot be empty."),
         ERROR_CODE_DUPLICATE_TEMPLATE_TYPE("60008", "Notification template type : %s already exists " +
                 "in tenant registry: %s"),
+        ERROR_CODE_INVALID_SMS_TEMPLATE_CONTENT("60009", "SMS template cannot have a subject or footer"),
+        ERROR_CODE_EMPTY_TEMPLATE_CHANNEL("60010", "Notification template channel cannot be empty"),
         ERROR_CODE_ERROR_CREATING_REGISTRY_RESOURCE("65001", "Error creating a registry resource " +
                 "from template : %s in locale : %s"),
         ERROR_CODE_ERROR_ADDING_TEMPLATE("65002", "Error when adding template : %s to tenant : %s"),

--- a/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/constants/I18nMgtConstants.java
+++ b/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/constants/I18nMgtConstants.java
@@ -79,7 +79,7 @@ public class I18nMgtConstants {
      */
     public enum ErrorMessages {
 
-        ERROR_CODE_NULL_TEMPLATE_OBJECT("60001", "Notification template object cannot be null."),
+        ERROR_CODE_NULL_TEMPLATE_OBJECT("60001", "Notification template is not provided."),
         ERROR_CODE_EMPTY_TEMPLATE_NAME("60002", "Notification template name cannot be empty."),
         ERROR_CODE_INVALID_CHARACTERS_IN_TEMPLATE_NAME("60003", "Invalid characters exists in the " +
                 "notification template display name : %s"),

--- a/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/exceptions/I18nEmailMgtInternalException.java
+++ b/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/exceptions/I18nEmailMgtInternalException.java
@@ -28,4 +28,15 @@ public class I18nEmailMgtInternalException extends I18nEmailMgtException {
     public I18nEmailMgtInternalException(String errorCode, String message, Throwable e) {
         super(errorCode, message, e);
     }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     *
+     * @param message The detail message
+     * @param cause   The cause
+     */
+    public I18nEmailMgtInternalException(String message, Throwable cause) {
+
+        super(message, cause);
+    }
 }

--- a/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/internal/I18nMgtServiceComponent.java
+++ b/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/internal/I18nMgtServiceComponent.java
@@ -27,6 +27,8 @@ import org.wso2.carbon.email.mgt.EmailTemplateManager;
 import org.wso2.carbon.email.mgt.EmailTemplateManagerImpl;
 import org.wso2.carbon.email.mgt.exceptions.I18nEmailMgtException;
 import org.wso2.carbon.identity.core.persistence.registry.RegistryResourceMgtService;
+import org.wso2.carbon.identity.governance.exceptions.notiification.NotificationTemplateManagerException;
+import org.wso2.carbon.identity.governance.service.notification.NotificationChannels;
 import org.wso2.carbon.identity.governance.service.notification.NotificationTemplateManager;
 import org.wso2.carbon.registry.core.service.RegistryService;
 import org.wso2.carbon.stratos.common.listeners.TenantMgtListener;
@@ -86,8 +88,9 @@ public class I18nMgtServiceComponent {
                 log.error("I18n Management - TenantMgtListener could not be registered");
             }
 
-            // Load default email templates.
+            // Load default notification templates.
             loadDefaultEmailTemplates();
+            loadDefaultSMSNotificationTemplates();
             log.debug("I18n Management is activated");
         } catch (Throwable e) {
             log.error("Error while activating I18n Management bundle", e);
@@ -102,6 +105,21 @@ public class I18nMgtServiceComponent {
             emailTemplateManager.addDefaultEmailTemplates(tenantDomain);
         } catch (I18nEmailMgtException e) {
             log.error("Error occurred while loading default email templates", e);
+        }
+    }
+
+    /**
+     * Load default SMS notification template configurations on server startup if they don't already exist.
+     */
+    private void loadDefaultSMSNotificationTemplates() {
+
+        String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
+        NotificationTemplateManager notificationTemplateManager = new EmailTemplateManagerImpl();
+        try {
+            notificationTemplateManager
+                    .addDefaultNotificationTemplates(NotificationChannels.SMS_CHANNEL.getChannelType(), tenantDomain);
+        } catch (NotificationTemplateManagerException e) {
+            log.error("Error occurred while loading default SMS templates", e);
         }
     }
 

--- a/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/internal/I18nMgtServiceComponent.java
+++ b/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/internal/I18nMgtServiceComponent.java
@@ -90,7 +90,7 @@ public class I18nMgtServiceComponent {
 
             // Load default notification templates.
             loadDefaultEmailTemplates();
-            loadDefaultSMSNotificationTemplates();
+            loadDefaultSMSTemplates();
             log.debug("I18n Management is activated");
         } catch (Throwable e) {
             log.error("Error while activating I18n Management bundle", e);
@@ -111,7 +111,7 @@ public class I18nMgtServiceComponent {
     /**
      * Load default SMS notification template configurations on server startup if they don't already exist.
      */
-    private void loadDefaultSMSNotificationTemplates() {
+    private void loadDefaultSMSTemplates() {
 
         String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
         NotificationTemplateManager notificationTemplateManager = new EmailTemplateManagerImpl();

--- a/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/internal/TenantManagementListener.java
+++ b/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/internal/TenantManagementListener.java
@@ -23,6 +23,9 @@ import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.email.mgt.EmailTemplateManager;
 import org.wso2.carbon.email.mgt.EmailTemplateManagerImpl;
 import org.wso2.carbon.email.mgt.exceptions.I18nEmailMgtException;
+import org.wso2.carbon.identity.governance.exceptions.notiification.NotificationTemplateManagerException;
+import org.wso2.carbon.identity.governance.service.notification.NotificationChannels;
+import org.wso2.carbon.identity.governance.service.notification.NotificationTemplateManager;
 import org.wso2.carbon.stratos.common.beans.TenantInfoBean;
 import org.wso2.carbon.stratos.common.exception.StratosException;
 import org.wso2.carbon.stratos.common.listeners.TenantMgtListener;
@@ -45,6 +48,16 @@ public class TenantManagementListener implements TenantMgtListener {
             templateManager.addDefaultEmailTemplates(tenantDomain);
         } catch (I18nEmailMgtException e) {
             String message = "Error occurred while loading default email templates for the tenant : " + tenantDomain;
+            log.error(message);
+            throw new StratosException(message, e);
+        }
+        try {
+            NotificationTemplateManager notificationTemplateManager = new EmailTemplateManagerImpl();
+            notificationTemplateManager.addDefaultNotificationTemplates(
+                    NotificationChannels.SMS_CHANNEL.getChannelType(), tenantDomain);
+        } catch (NotificationTemplateManagerException e) {
+            String message = "Error occurred while loading default SMS notification templates for the " +
+                    "tenant : " + tenantDomain;
             log.error(message);
             throw new StratosException(message, e);
         }

--- a/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/util/I18nEmailUtil.java
+++ b/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/util/I18nEmailUtil.java
@@ -76,7 +76,9 @@ public class I18nEmailUtil {
 
 
     /**
-     * @return
+     * Get the default email notification template List.
+     *
+     * @return List of default email notification templates.
      */
     public static List<EmailTemplate> getDefaultEmailTemplates() {
         String configFilePath = CarbonUtils.getCarbonConfigDirPath() + File.separator +
@@ -271,5 +273,27 @@ public class I18nEmailUtil {
         return collection;
     }
 
+    /**
+     * Prepend the operation scenario to the existing exception error code.
+     * (Eg: USR-20045)
+     *
+     * @param exceptionErrorCode Existing error code.
+     * @param scenario           Operation scenario
+     * @return New error code with the scenario prepended (NOTE: Return an empty String if the provided error code is
+     * empty)
+     */
+    public static String prependOperationScenarioToErrorCode(String exceptionErrorCode, String scenario) {
 
+        if (StringUtils.isNotEmpty(exceptionErrorCode)) {
+            // Check whether the scenario is already in the errorCode.
+            if (exceptionErrorCode.contains(I18nMgtConstants.ERROR_CODE_DELIMITER)) {
+                return exceptionErrorCode;
+            }
+            if (StringUtils.isNotEmpty(scenario)) {
+                exceptionErrorCode =
+                        scenario + I18nMgtConstants.ERROR_CODE_DELIMITER + exceptionErrorCode;
+            }
+        }
+        return exceptionErrorCode;
+    }
 }

--- a/components/email-mgt/org.wso2.carbon.email.mgt/src/test/java/org/wso2/carbon/email/mgt/EmailTemplateManagerImplTest.java
+++ b/components/email-mgt/org.wso2.carbon.email.mgt/src/test/java/org/wso2/carbon/email/mgt/EmailTemplateManagerImplTest.java
@@ -19,7 +19,6 @@ import static org.mockito.MockitoAnnotations.initMocks;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 import org.apache.commons.lang.StringUtils;
-import org.mockito.InjectMocks;
 import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.powermock.api.mockito.PowerMockito;
@@ -27,7 +26,6 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.testng.PowerMockTestCase;
 import org.testng.IObjectFactory;
 import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.BeforeTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.ObjectFactory;
 import org.testng.annotations.Test;
@@ -37,6 +35,7 @@ import static org.testng.Assert.*;
 
 import org.wso2.carbon.email.mgt.constants.I18nMgtConstants;
 import org.wso2.carbon.email.mgt.internal.I18nMgtDataHolder;
+import org.wso2.carbon.email.mgt.util.I18nEmailUtil;
 import org.wso2.carbon.identity.base.IdentityValidationUtil;
 import org.wso2.carbon.identity.core.persistence.registry.RegistryResourceMgtService;
 import org.wso2.carbon.identity.governance.IdentityMgtConstants;
@@ -94,7 +93,7 @@ public class EmailTemplateManagerImplTest extends PowerMockTestCase {
      * @param content             Template content
      * @throws Exception Error testing getNotificationTemplate implementation.
      */
-    @Test(dataProvider = "notificationTemplateDataProvider")
+    @Test(dataProvider = "notificationTemplateDataProvider", enabled = true)
     public void testGetNotificationTemplate(String notificationChannel, String displayName, String type, String locale,
             String contentType, byte[] content) throws Exception {
 
@@ -131,7 +130,7 @@ public class EmailTemplateManagerImplTest extends PowerMockTestCase {
      * @param contentType         Content type
      * @throws Exception Error testing getNotificationTemplate implementation.
      */
-    @Test(dataProvider = "invalidNotificationTemplateDataProvider")
+    @Test(dataProvider = "invalidNotificationTemplateDataProvider", enabled = true)
     public void testGetNotificationTemplateErrors(String notificationChannel, String displayName, String type,
             String locale, String contentType, boolean isValidTemplate, boolean isValidLocale, String errorMsg,
             String expectedErrorCode, byte[] content) throws Exception {
@@ -245,13 +244,16 @@ public class EmailTemplateManagerImplTest extends PowerMockTestCase {
 
         // Invalid template type.
         String errorMsg1 = "Invalid template type : ";
-        String expectedErrorCode1 = IdentityMgtConstants.ErrorMessages.ERROR_CODE_INVALID_NOTIFICATION_TEMPLATE
-                .getCode();
+        String expectedErrorCode1 = I18nEmailUtil.prependOperationScenarioToErrorCode(
+                I18nMgtConstants.ErrorMessages.ERROR_CODE_INVALID_CHARACTERS_IN_TEMPLATE_NAME.getCode(),
+                I18nMgtConstants.ErrorScenarios.EMAIL_TEMPLATE_MANAGER);
 
         // Invalid template locale.
         String errorMsg2 = "Invalid template locale : ";
-        String expectedErrorCode2 = IdentityMgtConstants.ErrorMessages.ERROR_CODE_INVALID_NOTIFICATION_TEMPLATE
-                .getCode();
+        String expectedErrorCode2 =
+                I18nEmailUtil.prependOperationScenarioToErrorCode(
+                        I18nMgtConstants.ErrorMessages.ERROR_CODE_INVALID_CHARACTERS_IN_LOCALE.getCode(),
+                        I18nMgtConstants.ErrorScenarios.EMAIL_TEMPLATE_MANAGER);
 
         // Template 1: SMS.
         String notificationChannel1 = NotificationChannels.SMS_CHANNEL.getChannelType();

--- a/components/email-mgt/org.wso2.carbon.email.mgt/src/test/resources/email/email-admin-config.xml
+++ b/components/email-mgt/org.wso2.carbon.email.mgt/src/test/resources/email/email-admin-config.xml
@@ -1,0 +1,1482 @@
+<!--
+ ~ Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ ~
+ ~ WSO2 Inc. licenses this file to you under the Apache License,
+ ~ Version 2.0 (the "License"); you may not use this file except
+ ~ in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~ http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied.  See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+ -->
+
+<!--
+     Contains the email templates which is used by identity recovery, account confirmation, OTP and account unlock features.
+     This will be only loaded once. There after you need to use "Email templates" from Configuration menu for changes.
+  -->
+
+<configurations>
+    <configuration type="passwordReset" display="PasswordReset" locale="en_US" emailContentType="text/html">
+        <subject>WSO2 - Password Reset</subject>
+        <body><![CDATA[<table align="center" cellpadding="0" cellspacing="0" border="0" width="100%"bgcolor="#f0f0f0">
+            <tr>
+            <td style="padding: 30px 30px 20px 30px;">
+                <table cellpadding="0" cellspacing="0" border="0" width="100%" bgcolor="#ffffff" style="max-width: 650px; margin: auto;">
+                <tr>
+                    <td colspan="2" align="center" style="background-color: #333; padding: 40px;">
+                        <a href="http://wso2.com/" target="_blank"><img src="http://cdn.wso2.com/wso2/newsletter/images/nl-2017/wso2-logo-transparent.png" border="0" /></a>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2" align="center" style="padding: 50px 50px 0px 50px;">
+                        <h1 style="padding-right: 0em; margin: 0; line-height: 40px; font-weight:300; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 1em;">
+                            Password Reset
+                        </h1>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="text-align: left; padding: 0px 50px 20px 50px;" valign="top">
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 3%;">
+                            Hi {{user.claim.givenname}},
+                        </p>
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 3%;">
+                            We received a request to reset the password for the <b>{{user-name}}</b> account that is associated with this email address.<br>
+                            If you made this request, please click the button below to securely reset your password.
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="padding: 0px 50px 0px 50px; text-align: left;">
+                        <table align="left" cellpadding="0" cellspacing="0" border="0" style="border-radius: 4px; background-color: #ff5000;">
+                            <tr>
+                                <td style="border-radius: 6px;  padding: 14px 0px;">
+                                    <a href="{{carbon.product-url}}/accountrecoveryendpoint/confirmrecovery.do?confirmation={{confirmation-code}}&amp;userstoredomain={{userstore-domain}}&amp;username={{url:user-name}}&amp;tenantdomain={{tenant-domain}}&amp;callback={{callback}}"
+                                       target="_blank" style="width: 230px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif;  font-size: 18px; line-height: 21px; font-weight: 600; color: #fff; text-decoration: none; background-color: #ff5000; text-align: center; display: inline-block; cursor: pointer;">Reset Password</a>
+                                </td>
+                            </tr>
+                        </table>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="text-align: left; padding: 40px 50px 0px 50px;" valign="top">
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #505050; text-align: left;">
+                            If clicking the button doesn't seem to work, you can copy and paste the following link into your browser. <br/>
+                            <a style="word-break: break-all; color: #ff5000;font-size: 14px;" target="_blank"
+                               href="{{carbon.product-url}}/accountrecoveryendpoint/confirmrecovery.do?confirmation={{confirmation-code}}&amp;userstoredomain={{userstore-domain}}&amp;username={{url:user-name}}&amp;tenantdomain={{tenant-domain}}&amp;callback={{callback}}">
+                                {{carbon.product-url}}/accountrecoveryendpoint/confirmrecovery.do?confirmation={{confirmation-code}}&amp;userstoredomain={{userstore-domain}}&amp;username={{url:user-name}}&amp;tenantdomain={{tenant-domain}}&amp;callback={{callback}}</a>
+                        </p>
+                        <br>
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 3%;">
+                            If you did not request to have your {{user-name}} password reset, disregard this email and no changes to your account will be made.
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="text-align: left; padding: 30px 50px 50px 50px" valign="top">
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #505050; text-align: left;">
+                            Thanks,<br/>WSO2 Identity Server Team
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2" align="center" style="padding: 20px 40px 40px 40px;" bgcolor="#f0f0f0">
+                        <p style="font-size: 12px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #777;">
+                            &copy; 2018
+                            <a href="http://wso2.com/" target="_blank" style="color: #777; text-decoration: none">WSO2</a>
+                            <br>
+                            787 Castro Street, Mountain View, CA 94041.
+                        </p>
+                    </td>
+                </tr>
+                </table>
+            </td>
+            </tr>
+        </table>]]></body>
+        <footer>---</footer>
+    </configuration>
+    <configuration type="resendPasswordReset" display="resendPasswordReset" locale="en_US" emailContentType="text/html">
+        <subject>WSO2 - Resend Password Reset</subject>
+        <body><![CDATA[<table align="center" cellpadding="0" cellspacing="0" border="0" width="100%"bgcolor="#f0f0f0">
+            <tr>
+            <td style="padding: 30px 30px 20px 30px;">
+                <table cellpadding="0" cellspacing="0" border="0" width="100%" bgcolor="#ffffff" style="max-width: 650px; margin: auto;">
+                <tr>
+                    <td colspan="2" align="center" style="background-color: #333; padding: 40px;">
+                        <a href="http://wso2.com/" target="_blank"><img src="http://cdn.wso2.com/wso2/newsletter/images/nl-2017/wso2-logo-transparent.png" border="0" /></a>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2" align="center" style="padding: 50px 50px 0px 50px;">
+                        <h1 style="padding-right: 0em; margin: 0; line-height: 40px; font-weight:300; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 1em;">
+                            Resend Password Reset
+                        </h1>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="text-align: left; padding: 0px 50px 20px 50px;" valign="top">
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 3%;">
+                            Hi {{user.claim.givenname}},
+                        </p>
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 3%;">
+                            We received a request to reset the password for the <b>{{user-name}}</b> account that is associated with this email address.<br>
+                            If you made this request, please click the button below to securely reset your password.
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="padding: 0px 50px 0px 50px; text-align: left;">
+                        <table align="left" cellpadding="0" cellspacing="0" border="0" style="border-radius: 4px; background-color: #ff5000;">
+                            <tr>
+                                <td style="border-radius: 6px;  padding: 14px 0px;">
+                                    <a href="{{carbon.product-url}}/accountrecoveryendpoint/confirmrecovery.do?confirmation={{confirmation-code}}&amp;userstoredomain={{userstore-domain}}&amp;username={{url:user-name}}&amp;tenantdomain={{tenant-domain}}&amp;callback={{callback}}"
+                                       target="_blank" style="width: 230px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif;  font-size: 18px; line-height: 21px; font-weight: 600; color: #fff; text-decoration: none; background-color: #ff5000; text-align: center; display: inline-block; cursor: pointer;">Reset Password</a>
+                                </td>
+                            </tr>
+                        </table>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="text-align: left; padding: 40px 50px 0px 50px;" valign="top">
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #505050; text-align: left;">
+                            If clicking the button doesn't seem to work, you can copy and paste the following link into your browser. <br/>
+                            <a style="word-break: break-all; color: #ff5000;font-size: 14px;" target="_blank"
+                               href="{{carbon.product-url}}/accountrecoveryendpoint/confirmrecovery.do?confirmation={{confirmation-code}}&amp;userstoredomain={{userstore-domain}}&amp;username={{url:user-name}}&amp;tenantdomain={{tenant-domain}}&amp;callback={{callback}}">
+                                {{carbon.product-url}}/accountrecoveryendpoint/confirmrecovery.do?confirmation={{confirmation-code}}&amp;userstoredomain={{userstore-domain}}&amp;username={{url:user-name}}&amp;tenantdomain={{tenant-domain}}&amp;callback={{callback}}</a>
+                        </p>
+                        <br>
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 3%;">
+                            If you did not request to have your {{user-name}} password reset, disregard this email and no changes to your account will be made.
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="text-align: left; padding: 30px 50px 50px 50px" valign="top">
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #505050; text-align: left;">
+                            Thanks,<br/>WSO2 Identity Server Team
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2" align="center" style="padding: 20px 40px 40px 40px;" bgcolor="#f0f0f0">
+                        <p style="font-size: 12px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #777;">
+                            &copy; 2018
+                            <a href="http://wso2.com/" target="_blank" style="color: #777; text-decoration: none">WSO2</a>
+                            <br>
+                            787 Castro Street, Mountain View, CA 94041.
+                        </p>
+                    </td>
+                </tr>
+                </table>
+            </td>
+            </tr>
+        </table>]]></body>
+        <footer>---</footer>
+    </configuration>
+    <configuration type="emailConfirm" display="EmailConfirm" locale="en_US" emailContentType="text/html">
+        <subject>WSO2 - Email Confirmation</subject>
+        <body><![CDATA[<table align="center" cellpadding="0" cellspacing="0" border="0" width="100%"bgcolor="#f0f0f0">
+            <tr>
+            <td style="padding: 30px 30px 20px 30px;">
+                <table cellpadding="0" cellspacing="0" border="0" width="100%" bgcolor="#ffffff" style="max-width: 650px; margin: auto;">
+                <tr>
+                    <td colspan="2" align="center" style="background-color: #333; padding: 40px;">
+                        <a href="http://wso2.com/" target="_blank"><img src="http://cdn.wso2.com/wso2/newsletter/images/nl-2017/wso2-logo-transparent.png" border="0" /></a>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2" align="center" style="padding: 50px 50px 0px 50px;">
+                        <h1 style="padding-right: 0em; margin: 0; line-height: 40px; font-weight:300; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 1em;">
+                            Email Confirmation
+                        </h1>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="text-align: left; padding: 0px 50px 20px 50px;" valign="top">
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 3%;">
+                            Hi {{user.claim.givenname}},
+                        </p>
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 3%;">
+                            You have created an account with the following user name. <br>
+                            User Name: <b>{{user-name}}</b><br>
+                            Please click the button below to confirm your account.
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="padding: 0px 50px 0px 50px; text-align: left;">
+                        <table align="left" cellpadding="0" cellspacing="0" border="0" style="border-radius: 4px; background-color: #ff5000;">
+                            <tr>
+                                <td style="border-radius: 6px;  padding: 14px 0px;">
+                                    <a href="{{carbon.product-url}}/accountrecoveryendpoint/confirmregistration.do?confirmation={{confirmation-code}}&amp;userstoredomain={{userstore-domain}}&amp;username={{url:user-name}}&amp;tenantdomain={{tenant-domain}}"
+                                       target="_blank" style="width: 230px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif;  font-size: 18px; line-height: 21px; font-weight: 600; color: #fff; text-decoration: none; background-color: #ff5000; text-align: center; display: inline-block;cursor: pointer;">Confirm Account</a>
+                                </td>
+                            </tr>
+                        </table>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="text-align: left; padding: 40px 50px 0px 50px;" valign="top">
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #505050; text-align: left;">
+                            If clicking the button doesn't seem to work, you can copy and paste the following link into your browser. <br/>
+                            <a style="word-break: break-all; color: #ff5000; font-size: 14px" target="_blank"
+                               href="{{carbon.product-url}}/accountrecoveryendpoint/confirmregistration.do?confirmation={{confirmation-code}}&amp;userstoredomain={{userstore-domain}}&amp;username={{url:user-name}}&amp;tenantdomain={{tenant-domain}}">
+                                {{carbon.product-url}}/accountrecoveryendpoint/confirmregistration.do?confirmation={{confirmation-code}}&amp;userstoredomain={{userstore-domain}}&amp;username={{url:user-name}}&amp;tenantdomain={{tenant-domain}}</a>
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="text-align: left; padding: 30px 50px 50px 50px;" valign="top">
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #505050; text-align: left;">
+                            Thanks,<br/>WSO2 Identity Server Team
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2" align="center" style="padding: 20px 40px 40px 40px;" bgcolor="#f0f0f0">
+                        <p style="font-size: 12px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #777;">
+                            &copy; 2018
+                            <a href="http://wso2.com/" target="_blank" style="color: #777; text-decoration: none">WSO2</a>
+                            <br>
+                            787 Castro Street, Mountain View, CA 94041.
+                        </p>
+                    </td>
+                </tr>
+                </table>
+            </td>
+            </tr>
+        </table>]]></body>
+        <footer>---</footer>
+    </configuration>
+    <configuration type="accountIdRecovery" display="AccountIdRecovery" locale="en_US" emailContentType="text/html">
+        <subject>WSO2 - Account Recovery</subject>
+        <body><![CDATA[<table align="center" cellpadding="0" cellspacing="0" border="0" width="100%"bgcolor="#f0f0f0">
+            <tr>
+            <td style="padding: 30px 30px 20px 30px;">
+                <table cellpadding="0" cellspacing="0" border="0" width="100%" bgcolor="#ffffff" style="max-width: 650px; margin: auto;">
+                <tr>
+                    <td colspan="2" align="center" style="background-color: #333; padding: 40px;">
+                        <a href="http://wso2.com/" target="_blank"><img src="http://cdn.wso2.com/wso2/newsletter/images/nl-2017/wso2-logo-transparent.png" border="0"/></a>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2" align="center" style="padding: 50px 50px 0px 50px;">
+                        <h1 style="padding-right: 0em; margin: 0; line-height: 40px; font-weight:300; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 1em;">
+                            Account Recovery
+                        </h1>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="text-align: left; padding: 0px 50px;" valign="top">
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 3%;">
+                            Hi {{user.claim.givenname}},
+                        </p>
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 3%;">
+                            We received a request to recover your account user name. The account associated with us indicates that
+                            your user name is <b>{{userstore-domain}}/{{user-name}}@{{tenant-domain}}</b>.
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="text-align: left; padding: 30px 50px 50px 50px" valign="top">
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #505050; text-align: left;">
+                            Thanks,<br/>WSO2 Identity Server Team
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2" align="center" style="padding: 20px 40px 40px 40px;" bgcolor="#f0f0f0">
+                        <p style="font-size: 12px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #777;">
+                            &copy; 2018
+                            <a href="http://wso2.com/" target="_blank" style="color: #777; text-decoration: none">WSO2</a>
+                            <br>
+                            787 Castro Street, Mountain View, CA 94041.
+                        </p>
+                    </td>
+                </tr>
+                </table>
+            </td>
+            </tr>
+        </table>]]></body>
+        <footer>---</footer>
+    </configuration>
+    <configuration type="accountConfirmation" display="AccountConfirmation" locale="en_US" emailContentType="text/html">
+        <subject>WSO2 - Account Confirmation</subject>
+        <body><![CDATA[<table align="center" cellpadding="0" cellspacing="0" border="0" width="100%"bgcolor="#f0f0f0">
+            <tr>
+            <td style="padding: 30px 30px 20px 30px;">
+                <table cellpadding="0" cellspacing="0" border="0" width="100%" bgcolor="#ffffff" style="max-width: 650px; margin: auto;">
+                <tr>
+                    <td colspan="2" align="center" style="background-color: #333; padding: 40px;">
+                        <a href="http://wso2.com/" target="_blank"><img src="http://cdn.wso2.com/wso2/newsletter/images/nl-2017/wso2-logo-transparent.png" border="0" /></a>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2" align="center" style="padding: 50px 50px 0px 50px;">
+                        <h1 style="padding-right: 0em; margin: 0; line-height: 40px; font-weight:300; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 1em;">
+                            Account Confirmation
+                        </h1>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="text-align: left; padding: 0px 50px 20px 50px;" valign="top">
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 3%;">
+                            Hi {{user.claim.givenname}},
+                        </p>
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 3%;">
+                            You have created an account with the following user name. <br>
+                            User Name: <b>{{user-name}}</b><br>
+                            Please click the button below to confirm your account.
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="padding: 0px 50px 0px 50px; text-align: left;">
+                        <table align="left" cellpadding="0" cellspacing="0" border="0" style="border-radius: 4px; background-color: #ff5000;">
+                            <tr>
+                                <td style="border-radius: 6px;  padding: 14px 0px;">
+                                    <a href="{{carbon.product-url}}/accountrecoveryendpoint/confirmregistration.do?confirmation={{confirmation-code}}&amp;userstoredomain={{userstore-domain}}&amp;username={{url:user-name}}&amp;tenantdomain={{tenant-domain}}&amp;callback={{callback}}"
+                                       target="_blank" style="width: 230px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif;  font-size: 18px; line-height: 21px; font-weight: 600; color: #fff; text-decoration: none; background-color: #ff5000; text-align: center; display: inline-block;cursor: pointer;">Confirm Account</a>
+                                </td>
+                            </tr>
+                        </table>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="text-align: left; padding: 40px 50px 0px 50px;" valign="top">
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #505050; text-align: left;">
+                            If clicking the button doesn't seem to work, you can copy and paste the following link into your browser. <br/>
+                            <a style="word-break: break-all; color: #ff5000; font-size: 14px" target="_blank"
+                               href="{{carbon.product-url}}/accountrecoveryendpoint/confirmregistration.do?confirmation={{confirmation-code}}&amp;userstoredomain={{userstore-domain}}&amp;username={{url:user-name}}&amp;tenantdomain={{tenant-domain}}&amp;callback={{callback}}">
+                                {{carbon.product-url}}/accountrecoveryendpoint/confirmregistration.do?confirmation={{confirmation-code}}&amp;userstoredomain={{userstore-domain}}&amp;username={{url:user-name}}&amp;tenantdomain={{tenant-domain}}&amp;callback={{callback}}
+                            </a>
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="text-align: left; padding: 30px 50px 50px 50px;" valign="top">
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #505050; text-align: left;">
+                            Thanks,<br/>WSO2 Identity Server Team
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2" align="center" style="padding: 20px 40px 40px 40px;" bgcolor="#f0f0f0">
+                        <p style="font-size: 12px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #777;">
+                            &copy; 2018
+                            <a href="http://wso2.com/" target="_blank" style="color: #777; text-decoration: none">WSO2</a>
+                            <br>
+                            787 Castro Street, Mountain View, CA 94041.
+                        </p>
+                    </td>
+                </tr>
+                </table>
+            </td>
+            </tr>
+        </table>]]></body>
+        <footer>---</footer>
+    </configuration>
+    <configuration type="resendAccountConfirmation" display="ResendAccountConfirmation" locale="en_US" emailContentType="text/html">
+        <subject>WSO2 - Resend Account Confirmation</subject>
+        <body><![CDATA[<table align="center" cellpadding="0" cellspacing="0" border="0" width="100%"bgcolor="#f0f0f0">
+            <tr>
+            <td style="padding: 30px 30px 20px 30px;">
+                <table cellpadding="0" cellspacing="0" border="0" width="100%" bgcolor="#ffffff" style="max-width: 650px; margin: auto;">
+                <tr>
+                    <td colspan="2" align="center" style="background-color: #333; padding: 40px;">
+                        <a href="http://wso2.com/" target="_blank"><img src="http://cdn.wso2.com/wso2/newsletter/images/nl-2017/wso2-logo-transparent.png" border="0" /></a>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2" align="center" style="padding: 50px 50px 0px 50px;">
+                        <h1 style="padding-right: 0em; margin: 0; line-height: 40px; font-weight:300; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 1em;">
+                            Resend Account Confirmation
+                        </h1>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="text-align: left; padding: 0px 50px 20px 50px;" valign="top">
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 3%;">
+                            Hi {{user.claim.givenname}},
+                        </p>
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 3%;">
+                            You have created an account with the following user name. <br>
+                            User Name: <b>{{user-name}}</b><br>
+                            Please click the below button to confirm your account.
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="padding: 0px 50px 0px 50px; text-align: left;">
+                        <table align="left" cellpadding="0" cellspacing="0" border="0" style="border-radius: 4px; background-color: #ff5000;">
+                            <tr>
+                                <td style="border-radius: 6px;  padding: 14px 0px;">
+                                    <a href="{{carbon.product-url}}/accountrecoveryendpoint/confirmregistration.do?confirmation={{confirmation-code}}&amp;userstoredomain={{userstore-domain}}&amp;username={{url:user-name}}&amp;tenantdomain={{tenant-domain}}"
+                                       target="_blank" style="width: 230px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif;  font-size: 18px; line-height: 21px; font-weight: 600; color: #fff; text-decoration: none; background-color: #ff5000; text-align: center; display: inline-block;cursor: pointer;">Confirm Registration</a>
+                                </td>
+                            </tr>
+                        </table>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="text-align: left; padding: 40px 50px 0px 50px;" valign="top">
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #505050; text-align: left;">
+                            If clicking the button doesn't seem to work, you can copy and paste the following link into your browser. <br/>
+                            <a style="word-break: break-all; color: #ff5000; font-size: 14px" target="_blank"
+                               href="{{carbon.product-url}}/accountrecoveryendpoint/confirmregistration.do?confirmation={{confirmation-code}}&amp;userstoredomain={{userstore-domain}}&amp;username={{url:user-name}}&amp;tenantdomain={{tenant-domain}}">
+                                {{carbon.product-url}}/accountrecoveryendpoint/confirmregistration.do?confirmation={{confirmation-code}}&amp;userstoredomain={{userstore-domain}}&amp;username={{url:user-name}}&amp;tenantdomain={{tenant-domain}}
+                            </a>
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="text-align: left; padding: 30px 50px 50px 50px;" valign="top">
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #505050; text-align: left;">
+                            Thanks,<br/>WSO2 Identity Server Team
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2" align="center" style="padding: 20px 40px 40px 40px;" bgcolor="#f0f0f0">
+                        <p style="font-size: 12px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #777;">
+                            &copy; 2018
+                            <a href="http://wso2.com/" target="_blank" style="color: #777; text-decoration: none">WSO2</a>
+                            <br>
+                            787 Castro Street, Mountain View, CA 94041.
+                        </p>
+                    </td>
+                </tr>
+                </table>
+            </td>
+            </tr>
+        </table>]]></body>
+        <footer>---</footer>
+    </configuration>
+    <configuration type="temporaryPassword" display="TemporaryPassword" locale="en_US" emailContentType="text/html">
+        <subject>WSO2 - Temporary Password</subject>
+        <body><![CDATA[<table align="center" cellpadding="0" cellspacing="0" border="0" width="100%"bgcolor="#f0f0f0">
+            <tr>
+            <td style="padding: 30px 30px 20px 30px;">
+                <table cellpadding="0" cellspacing="0" border="0" width="100%" bgcolor="#ffffff" style="max-width: 650px; margin: auto;">
+                <tr>
+                    <td colspan="2" align="center" style="background-color: #333; padding: 40px;">
+                        <a href="http://wso2.com/" target="_blank"><img src="http://cdn.wso2.com/wso2/newsletter/images/nl-2017/wso2-logo-transparent.png" border="0" /></a>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2" align="center" style="padding: 50px 50px 0px 50px;">
+                        <h1 style="padding-right: 0em; margin: 0; line-height: 40px; font-weight:300; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 1em;">
+                            Temporary Password
+                        </h1>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="text-align: left; padding: 0px 50px;" valign="top">
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 3%;">
+                            Hi {{user.claim.givenname}},
+                        </p>
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 3%;">
+                            Please find your temporary password below.<br>
+                            User Name: <b>{{user-name}}</b><br>
+                            Temporary Password: <b>{{temporary-password}}</b>
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="text-align: left; padding: 30px 50px 50px 50px" valign="top">
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #505050; text-align: left;">
+                            Thanks,<br/>WSO2 Identity Server Team
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2" align="center" style="padding: 20px 40px 40px 40px;" bgcolor="#f0f0f0">
+                        <p style="font-size: 12px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #777;">
+                            &copy; 2018
+                            <a href="http://wso2.com/" target="_blank" style="color: #777; text-decoration: none">WSO2</a>
+                            <br>
+                            787 Castro Street, Mountain View, CA 94041.
+                        </p>
+                    </td>
+                </tr>
+                </table>
+            </td>
+            </tr>
+        </table>]]></body>
+        <footer>---</footer>
+    </configuration>
+    <configuration type="otp" display="OneTimePassword" locale="en_US" emailContentType="text/html">
+        <subject>WSO2 - One Time Password Reset</subject>
+        <body><![CDATA[<table align="center" cellpadding="0" cellspacing="0" border="0" width="100%"bgcolor="#f0f0f0">
+            <tr>
+            <td style="padding: 30px 30px 20px 30px;">
+                <table cellpadding="0" cellspacing="0" border="0" width="100%" bgcolor="#ffffff" style="max-width: 650px; margin: auto;">
+                <tr>
+                    <td colspan="2" align="center" style="background-color: #333; padding: 40px;">
+                        <a href="http://wso2.com/" target="_blank"><img src="http://cdn.wso2.com/wso2/newsletter/images/nl-2017/wso2-logo-transparent.png" border="0" /></a>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2" align="center" style="padding: 50px 50px 0px 50px;">
+                        <h1 style="padding-right: 0em; margin: 0; line-height: 40px; font-weight:300; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 1em;">
+                            One Time Password Reset
+                        </h1>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="text-align: left; padding: 0px 50px;" valign="top">
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 3%;">
+                            Hi {{user.claim.givenname}},
+                        </p>
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 3%;">
+                            Please use the password <b>{{otp-password}}</b> as the new password for your next login.
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="text-align: left; padding: 30px 50px 50px 50px" valign="top">
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #505050; text-align: left;">
+                            Thanks,<br/>WSO2 Identity Server Team
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2" align="center" style="padding: 20px 40px 40px 40px;" bgcolor="#f0f0f0">
+                        <p style="font-size: 12px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #777;">
+                            &copy; 2018
+                            <a href="http://wso2.com/" target="_blank" style="color: #777; text-decoration: none">WSO2</a>
+                            <br>
+                            787 Castro Street, Mountain View, CA 94041.
+                        </p>
+                    </td>
+                </tr>
+                </table>
+            </td>
+            </tr>
+        </table>]]></body>
+        <footer>---</footer>
+    </configuration>
+    <configuration type="askPassword" display="AskPassword" locale="en_US" emailContentType="text/html">
+        <subject>WSO2 - Create Password for New Account</subject>
+        <body><![CDATA[<table align="center" cellpadding="0" cellspacing="0" border="0" width="100%"bgcolor="#f0f0f0">
+            <tr>
+            <td style="padding: 30px 30px 20px 30px;">
+                <table cellpadding="0" cellspacing="0" border="0" width="100%" bgcolor="#ffffff" style="max-width: 650px; margin: auto;">
+                <tr>
+                    <td colspan="2" align="center" style="background-color: #333; padding: 40px;">
+                        <a href="http://wso2.com/" target="_blank"><img src="http://cdn.wso2.com/wso2/newsletter/images/nl-2017/wso2-logo-transparent.png" border="0" /></a>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2" align="center" style="padding: 50px 50px 0px 50px;">
+                        <h1 style="padding-right: 0em; margin: 0; line-height: 40px; font-weight:300; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 1em;">
+                            Password Change for New Account
+                        </h1>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="text-align: left; padding: 0px 50px 20px 50px;" valign="top">
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 3%;">
+                            Hi {{user-name}},
+                        </p>
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 3%;">
+                            Please create your password for the newly created account <b>{{user-name}}</b>. <br>
+                            Please click the button below to create the password.
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="padding: 0px 50px 0px 50px; text-align: left;">
+                        <table align="left" cellpadding="0" cellspacing="0" border="0" style="border-radius: 4px; background-color: #ff5000;">
+                            <tr>
+                                <td style="border-radius: 6px;  padding: 14px 0px;">
+                                    <a href="{{carbon.product-url}}/accountrecoveryendpoint/confirmrecovery.do?confirmation={{confirmation-code}}&amp;userstoredomain={{userstore-domain}}&amp;username={{url:user-name}}&amp;tenantdomain={{tenant-domain}}"
+                                       target="_blank" style="width: 230px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif;  font-size: 18px; line-height: 21px; font-weight: 600; color: #fff; text-decoration: none; background-color: #ff5000; text-align: center; display: inline-block;cursor: pointer;">Create Password</a>
+                                </td>
+                            </tr>
+                        </table>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="text-align: left; padding: 40px 50px 0px 50px;" valign="top">
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #505050; text-align: left;">
+                            If clicking the button doesn't seem to work, you can copy and paste the following link into your browser. <br/>
+                            <a style="word-break: break-all; color: #ff5000; font-size: 14px" target="_blank"
+                               href="{{carbon.product-url}}/accountrecoveryendpoint/confirmrecovery.do?confirmation={{confirmation-code}}&amp;userstoredomain={{userstore-domain}}&amp;username={{url:user-name}}&amp;tenantdomain={{tenant-domain}}">
+                                {{carbon.product-url}}/accountrecoveryendpoint/confirmrecovery.do?confirmation={{confirmation-code}}&amp;userstoredomain={{userstore-domain}}&amp;username={{url:user-name}}&amp;tenantdomain={{tenant-domain}}
+                            </a>
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="text-align: left; padding: 30px 50px 50px 50px;" valign="top">
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #505050; text-align: left;">
+                            Thanks,<br/>WSO2 Identity Server Team
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2" align="center" style="padding: 20px 40px 40px 40px;" bgcolor="#f0f0f0">
+                        <p style="font-size: 12px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #777;">
+                            &copy; 2018
+                            <a href="http://wso2.com/" target="_blank" style="color: #777; text-decoration: none">WSO2</a>
+                            <br>
+                            787 Castro Street, Mountain View, CA 94041.
+                        </p>
+                    </td>
+                </tr>
+                </table>
+            </td>
+            </tr>
+        </table>]]></body>
+        <footer>---</footer>
+    </configuration>
+    <configuration type="resendAskPassword" display="resendAskPassword" locale="en_US" emailContentType="text/html">
+        <subject>WSO2 - Resend Create Password for New Account</subject>
+        <body><![CDATA[<table align="center" cellpadding="0" cellspacing="0" border="0" width="100%"bgcolor="#f0f0f0">
+            <tr>
+            <td style="padding: 30px 30px 20px 30px;">
+                <table cellpadding="0" cellspacing="0" border="0" width="100%" bgcolor="#ffffff" style="max-width: 650px; margin: auto;">
+                <tr>
+                    <td colspan="2" align="center" style="background-color: #333; padding: 40px;">
+                        <a href="http://wso2.com/" target="_blank"><img src="http://cdn.wso2.com/wso2/newsletter/images/nl-2017/wso2-logo-transparent.png" border="0" /></a>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2" align="center" style="padding: 50px 50px 0px 50px;">
+                        <h1 style="padding-right: 0em; margin: 0; line-height: 40px; font-weight:300; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 1em;">
+                            Resend Password Change for New Account
+                        </h1>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="text-align: left; padding: 0px 50px 20px 50px;" valign="top">
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 3%;">
+                            Hi {{user-name}},
+                        </p>
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 3%;">
+                            Please create your password for the newly created account <b>{{user-name}}</b>. <br>
+                            Please click the button below to create the password.
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="padding: 0px 50px 0px 50px; text-align: left;">
+                        <table align="left" cellpadding="0" cellspacing="0" border="0" style="border-radius: 4px; background-color: #ff5000;">
+                            <tr>
+                                <td style="border-radius: 6px;  padding: 14px 0px;">
+                                    <a href="{{carbon.product-url}}/accountrecoveryendpoint/confirmrecovery.do?confirmation={{confirmation-code}}&amp;userstoredomain={{userstore-domain}}&amp;username={{url:user-name}}&amp;tenantdomain={{tenant-domain}}"
+                                       target="_blank" style="width: 230px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif;  font-size: 18px; line-height: 21px; font-weight: 600; color: #fff; text-decoration: none; background-color: #ff5000; text-align: center; display: inline-block;cursor: pointer;">Create Password</a>
+                                </td>
+                            </tr>
+                        </table>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="text-align: left; padding: 40px 50px 0px 50px;" valign="top">
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #505050; text-align: left;">
+                            If clicking the button doesn't seem to work, you can copy and paste the following link into your browser. <br/>
+                            <a style="word-break: break-all; color: #ff5000; font-size: 14px" target="_blank"
+                               href="{{carbon.product-url}}/accountrecoveryendpoint/confirmrecovery.do?confirmation={{confirmation-code}}&amp;userstoredomain={{userstore-domain}}&amp;username={{url:user-name}}&amp;tenantdomain={{tenant-domain}}">
+                                {{carbon.product-url}}/accountrecoveryendpoint/confirmrecovery.do?confirmation={{confirmation-code}}&amp;userstoredomain={{userstore-domain}}&amp;username={{url:user-name}}&amp;tenantdomain={{tenant-domain}}
+                            </a>
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="text-align: left; padding: 30px 50px 50px 50px;" valign="top">
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #505050; text-align: left;">
+                            Thanks,<br/>WSO2 Identity Server Team
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2" align="center" style="padding: 20px 40px 40px 40px;" bgcolor="#f0f0f0">
+                        <p style="font-size: 12px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #777;">
+                            &copy; 2018
+                            <a href="http://wso2.com/" target="_blank" style="color: #777; text-decoration: none">WSO2</a>
+                            <br>
+                            787 Castro Street, Mountain View, CA 94041.
+                        </p>
+                    </td>
+                </tr>
+                </table>
+            </td>
+            </tr>
+        </table>]]></body>
+        <footer>---</footer>
+    </configuration>
+    <configuration type="adminforcedpasswordreset" display="AdminForcedPasswordReset" locale="en_US" emailContentType="text/html">
+        <subject>WSO2 - Admin Forced Password Reset</subject>
+        <body><![CDATA[<table align="center" cellpadding="0" cellspacing="0" border="0" width="100%"bgcolor="#f0f0f0">
+            <tr>
+            <td style="padding: 30px 30px 20px 30px;">
+                <table cellpadding="0" cellspacing="0" border="0" width="100%" bgcolor="#ffffff" style="max-width: 650px; margin: auto;">
+                <tr>
+                    <td colspan="2" align="center" style="background-color: #333; padding: 40px;">
+                        <a href="http://wso2.com/" target="_blank"><img src="http://cdn.wso2.com/wso2/newsletter/images/nl-2017/wso2-logo-transparent.png" border="0" /></a>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2" align="center" style="padding: 50px 50px 0px 50px;">
+                        <h1 style="padding-right: 0em; margin: 0; line-height: 40px; font-weight:300; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 1em;">
+                            Admin Forced Password Reset
+                        </h1>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="text-align: left; padding: 0px 50px 20px 50px;" valign="top">
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 3%;">
+                            Hi {{user.claim.givenname}},
+                        </p>
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 3%;">
+                            Please click the button below to reset your password for the account <b>{{user-name}}</b>.
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="padding: 0px 50px 0px 50px; text-align: left;">
+                        <table align="left" cellpadding="0" cellspacing="0" border="0" style="border-radius: 4px; background-color: #ff5000;">
+                            <tr>
+                                <td style="border-radius: 6px;  padding: 14px 0px;">
+                                    <a href="{{carbon.product-url}}/accountrecoveryendpoint/confirmrecovery.do?confirmation={{confirmation-code}}&amp;userstoredomain={{userstore-domain}}&amp;username={{url:user-name}}&amp;tenantdomain={{tenant-domain}}"
+                                       target="_blank" style="width: 230px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif;  font-size: 18px; line-height: 21px; font-weight: 600; color: #fff; text-decoration: none; background-color: #ff5000; text-align: center; display: inline-block;cursor: pointer;">Reset Password</a>
+                                </td>
+                            </tr>
+                        </table>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="text-align: left; padding: 40px 50px 0px 50px;" valign="top">
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #505050; text-align: left;">
+                            If clicking the button doesn't seem to work, you can copy and paste the following link into your browser. <br/>
+                            <a style="word-break: break-all; color: #ff5000; font-size: 14px" target="_blank"
+                               href="{{carbon.product-url}}/accountrecoveryendpoint/confirmrecovery.do?confirmation={{confirmation-code}}&amp;userstoredomain={{userstore-domain}}&amp;username={{url:user-name}}&amp;tenantdomain={{tenant-domain}}">
+                                {{carbon.product-url}}/accountrecoveryendpoint/confirmrecovery.do?confirmation={{confirmation-code}}&amp;userstoredomain={{userstore-domain}}&amp;username={{url:user-name}}&amp;tenantdomain={{tenant-domain}}
+                            </a>
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="text-align: left; padding: 30px 50px 50px 50px;" valign="top">
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #505050; text-align: left;">
+                            Thanks,<br/>WSO2 Identity Server Team
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2" align="center" style="padding: 20px 40px 40px 40px;" bgcolor="#f0f0f0">
+                        <p style="font-size: 12px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #777;">
+                            &copy; 2018
+                            <a href="http://wso2.com/" target="_blank" style="color: #777; text-decoration: none">WSO2</a>
+                            <br>
+                            787 Castro Street, Mountain View, CA 94041.
+                        </p>
+                    </td>
+                </tr>
+                </table>
+            </td>
+            </tr>
+        </table>]]></body>
+        <footer>---</footer>
+    </configuration>
+    <configuration type="resendAdminForcedPasswordReset" display="resendAdminForcedPasswordReset" locale="en_US"
+                   emailContentType="text/html">
+        <subject>WSO2 - Resend Admin Forced Password Reset</subject>
+        <body><![CDATA[<table align="center" cellpadding="0" cellspacing="0" border="0" width="100%"bgcolor="#f0f0f0">
+            <tr>
+            <td style="padding: 30px 30px 20px 30px;">
+                <table cellpadding="0" cellspacing="0" border="0" width="100%" bgcolor="#ffffff" style="max-width: 650px; margin: auto;">
+                <tr>
+                    <td colspan="2" align="center" style="background-color: #333; padding: 40px;">
+                        <a href="http://wso2.com/" target="_blank"><img src="http://cdn.wso2.com/wso2/newsletter/images/nl-2017/wso2-logo-transparent.png" border="0" /></a>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2" align="center" style="padding: 50px 50px 0px 50px;">
+                        <h1 style="padding-right: 0em; margin: 0; line-height: 40px; font-weight:300; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 1em;">
+                            Resend Admin Forced Password Reset
+                        </h1>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="text-align: left; padding: 0px 50px 20px 50px;" valign="top">
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 3%;">
+                            Hi {{user.claim.givenname}},
+                        </p>
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 3%;">
+                            Please click the button below to reset your password for the account <b>{{user-name}}</b>.
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="padding: 0px 50px 0px 50px; text-align: left;">
+                        <table align="left" cellpadding="0" cellspacing="0" border="0" style="border-radius: 4px; background-color: #ff5000;">
+                            <tr>
+                                <td style="border-radius: 6px;  padding: 14px 0px;">
+                                    <a href="{{carbon.product-url}}/accountrecoveryendpoint/confirmrecovery.do?confirmation={{confirmation-code}}&amp;userstoredomain={{userstore-domain}}&amp;username={{url:user-name}}&amp;tenantdomain={{tenant-domain}}"
+                                       target="_blank" style="width: 230px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif;  font-size: 18px; line-height: 21px; font-weight: 600; color: #fff; text-decoration: none; background-color: #ff5000; text-align: center; display: inline-block;cursor: pointer;">Reset Password</a>
+                                </td>
+                            </tr>
+                        </table>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="text-align: left; padding: 40px 50px 0px 50px;" valign="top">
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #505050; text-align: left;">
+                            If clicking the button doesn't seem to work, you can copy and paste the following link into your browser. <br/>
+                            <a style="word-break: break-all; color: #ff5000; font-size: 14px" target="_blank"
+                               href="{{carbon.product-url}}/accountrecoveryendpoint/confirmrecovery.do?confirmation={{confirmation-code}}&amp;userstoredomain={{userstore-domain}}&amp;username={{url:user-name}}&amp;tenantdomain={{tenant-domain}}">
+                                {{carbon.product-url}}/accountrecoveryendpoint/confirmrecovery.do?confirmation={{confirmation-code}}&amp;userstoredomain={{userstore-domain}}&amp;username={{url:user-name}}&amp;tenantdomain={{tenant-domain}}
+                            </a>
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="text-align: left; padding: 30px 50px 50px 50px;" valign="top">
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #505050; text-align: left;">
+                            Thanks,<br/>WSO2 Identity Server Team
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2" align="center" style="padding: 20px 40px 40px 40px;" bgcolor="#f0f0f0">
+                        <p style="font-size: 12px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #777;">
+                            &copy; 2018
+                            <a href="http://wso2.com/" target="_blank" style="color: #777; text-decoration: none">WSO2</a>
+                            <br>
+                            787 Castro Street, Mountain View, CA 94041.
+                        </p>
+                    </td>
+                </tr>
+                </table>
+            </td>
+            </tr>
+        </table>]]></body>
+        <footer>---</footer>
+    </configuration>
+    <configuration type="adminforcedpasswordresetwithotp" display="AdminForcedPasswordResetWithOTP" locale="en_US" emailContentType="text/html">
+        <subject>WSO2 - Admin Forced Password Reset</subject>
+        <body><![CDATA[<table align="center" cellpadding="0" cellspacing="0" border="0" width="100%"bgcolor="#f0f0f0">
+            <tr>
+            <td style="padding: 30px 30px 20px 30px;">
+                <table cellpadding="0" cellspacing="0" border="0" width="100%" bgcolor="#ffffff" style="max-width: 650px; margin: auto;">
+                <tr>
+                    <td colspan="2" align="center" style="background-color: #333; padding: 40px;">
+                        <a href="http://wso2.com/" target="_blank"><img src="http://cdn.wso2.com/wso2/newsletter/images/nl-2017/wso2-logo-transparent.png" border="0" /></a>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2" align="center" style="padding: 50px 50px 0px 50px;">
+                        <h1 style="padding-right: 0em; margin: 0; line-height: 40px; font-weight:300; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 1em;">
+                            Admin Forced Password Reset
+                        </h1>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="text-align: left; padding: 0px 50px;" valign="top">
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 3%;">
+                            Hi {{user.claim.givenname}},
+                        </p>
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 3%;">
+                            We received a request to reset the password for the <b>{{user-name}}</b> account that is associated with this email address.<br>
+                            Please use below OTP as the password at next login and then reset your password.<br>
+                            OTP : <b>{{confirmation-code}}</b>
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="text-align: left; padding: 30px 50px 50px 50px" valign="top">
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #505050; text-align: left;">
+                            Thanks,<br/>WSO2 Identity Server Team
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2" align="center" style="padding: 20px 40px 40px 40px;" bgcolor="#f0f0f0">
+                        <p style="font-size: 12px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #777;">
+                            &copy; 2018
+                            <a href="http://wso2.com/" target="_blank" style="color: #777; text-decoration: none">WSO2</a>
+                            <br>
+                            787 Castro Street, Mountain View, CA 94041.
+                        </p>
+                    </td>
+                </tr>
+                </table>
+            </td>
+            </tr>
+        </table>]]></body>
+        <footer>---</footer>
+    </configuration>
+    <configuration type="resendAdminForcedPasswordResetWithOTP" display="resendAdminForcedPasswordResetWithOTP" locale="en_US" emailContentType="text/html">
+        <subject>WSO2 - Resend Admin Forced Password Reset</subject>
+        <body><![CDATA[<table align="center" cellpadding="0" cellspacing="0" border="0" width="100%"bgcolor="#f0f0f0">
+            <tr>
+            <td style="padding: 30px 30px 20px 30px;">
+                <table cellpadding="0" cellspacing="0" border="0" width="100%" bgcolor="#ffffff" style="max-width: 650px; margin: auto;">
+                <tr>
+                    <td colspan="2" align="center" style="background-color: #333; padding: 40px;">
+                        <a href="http://wso2.com/" target="_blank"><img src="http://cdn.wso2.com/wso2/newsletter/images/nl-2017/wso2-logo-transparent.png" border="0" /></a>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2" align="center" style="padding: 50px 50px 0px 50px;">
+                        <h1 style="padding-right: 0em; margin: 0; line-height: 40px; font-weight:300; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 1em;">
+                            Resend Admin Forced Password Reset
+                        </h1>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="text-align: left; padding: 0px 50px;" valign="top">
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 3%;">
+                            Hi {{user.claim.givenname}},
+                        </p>
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 3%;">
+                            We received a request to reset the password for the <b>{{user-name}}</b> account that is associated with this email address.<br>
+                            Please use below OTP as the password at next login and then reset your password.<br>
+                            OTP : <b>{{confirmation-code}}</b>
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="text-align: left; padding: 30px 50px 50px 50px" valign="top">
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #505050; text-align: left;">
+                            Thanks,<br/>WSO2 Identity Server Team
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2" align="center" style="padding: 20px 40px 40px 40px;" bgcolor="#f0f0f0">
+                        <p style="font-size: 12px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #777;">
+                            &copy; 2018
+                            <a href="http://wso2.com/" target="_blank" style="color: #777; text-decoration: none">WSO2</a>
+                            <br>
+                            787 Castro Street, Mountain View, CA 94041.
+                        </p>
+                    </td>
+                </tr>
+                </table>
+            </td>
+            </tr>
+        </table>]]></body>
+        <footer>---</footer>
+    </configuration>
+    <configuration type="accountUnlockAdmin" display="AccountUnlockAdmin" locale="en_US" emailContentType="text/html">
+        <subject>WSO2 - Your Account has been Unlocked</subject>
+        <body><![CDATA[<table align="center" cellpadding="0" cellspacing="0" border="0" width="100%"bgcolor="#f0f0f0">
+            <tr>
+            <td style="padding: 30px 30px 20px 30px;">
+                <table cellpadding="0" cellspacing="0" border="0" width="100%" bgcolor="#ffffff" style="max-width: 650px; margin: auto;">
+                <tr>
+                    <td colspan="2" align="center" style="background-color: #333; padding: 40px;">
+                        <a href="http://wso2.com/" target="_blank"><img src="http://cdn.wso2.com/wso2/newsletter/images/nl-2017/wso2-logo-transparent.png" border="0" /></a>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2" align="center" style="padding: 50px 50px 0px 50px;">
+                        <h1 style="padding-right: 0em; margin: 0; line-height: 40px; font-weight:300; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 1em;">
+                            Account Unlocked
+                        </h1>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="text-align: left; padding: 0px 50px;" valign="top">
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 3%;">
+                            Hi {{user.claim.givenname}},
+                        </p>
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 3%;">
+                            Please note that the account registered with the user name <b>{{user-name}}</b> has been unlocked by administrator.<br>
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="text-align: left; padding: 30px 50px 50px 50px" valign="top">
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #505050; text-align: left;">
+                            Thanks,<br/>WSO2 Identity Server Team
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2" align="center" style="padding: 20px 40px 40px 40px;" bgcolor="#f0f0f0">
+                        <p style="font-size: 12px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #777;">
+                            &copy; 2018
+                            <a href="http://wso2.com/" target="_blank" style="color: #777; text-decoration: none">WSO2</a>
+                            <br>
+                            787 Castro Street, Mountain View, CA 94041.
+                        </p>
+                    </td>
+                </tr>
+                </table>
+            </td>
+            </tr>
+        </table>]]></body>
+        <footer>---</footer>
+    </configuration>
+    <configuration type="accountUnlockTimeBased" display="AccountUnlockTimeBased" locale="en_US"
+                   emailContentType="text/html">
+        <subject>WSO2 - Your Account has been Unlocked</subject>
+        <body><![CDATA[<table align="center" cellpadding="0" cellspacing="0" border="0" width="100%"bgcolor="#f0f0f0">
+            <tr>
+            <td style="padding: 30px 30px 20px 30px;">
+                <table cellpadding="0" cellspacing="0" border="0" width="100%" bgcolor="#ffffff" style="max-width: 650px; margin: auto;">
+                <tr>
+                    <td colspan="2" align="center" style="background-color: #333; padding: 40px;">
+                        <a href="http://wso2.com/" target="_blank"><img src="http://cdn.wso2.com/wso2/newsletter/images/nl-2017/wso2-logo-transparent.png" border="0" /></a>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2" align="center" style="padding: 50px 50px 0px 50px;">
+                        <h1 style="padding-right: 0em; margin: 0; line-height: 40px; font-weight:300; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 1em;">
+                            Account Unlocked
+                        </h1>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="text-align: left; padding: 0px 50px;" valign="top">
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 3%;">
+                            Hi {{user.claim.givenname}},
+                        </p>
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 3%;">
+                            Please note that the account registered with the user name <b>{{user-name}}</b> has been unlocked automatically as the locked time exceeded.<br>
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="text-align: left; padding: 30px 50px 50px 50px" valign="top">
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #505050; text-align: left;">
+                            Thanks,<br/>WSO2 Identity Server Team
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2" align="center" style="padding: 20px 40px 40px 40px;" bgcolor="#f0f0f0">
+                        <p style="font-size: 12px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #777;">
+                            &copy; 2018
+                            <a href="http://wso2.com/" target="_blank" style="color: #777; text-decoration: none">WSO2</a>
+                            <br>
+                            787 Castro Street, Mountain View, CA 94041.
+                        </p>
+                    </td>
+                </tr>
+                </table>
+            </td>
+            </tr>
+        </table>]]></body>
+        <footer>---</footer>
+    </configuration>
+    <configuration type="accountLockFailedAttempt" display="AccountLockFailedAttempt" locale="en_US"
+                   emailContentType="text/html">
+        <subject>WSO2 - Your Account has been Locked</subject>
+        <body><![CDATA[<table align="center" cellpadding="0" cellspacing="0" border="0" width="100%"bgcolor="#f0f0f0">
+            <tr>
+            <td style="padding: 30px 30px 20px 30px;">
+                <table cellpadding="0" cellspacing="0" border="0" width="100%" bgcolor="#ffffff" style="max-width: 650px; margin: auto;">
+                <tr>
+                    <td colspan="2" align="center" style="background-color: #333; padding: 40px;">
+                        <a href="http://wso2.com/" target="_blank"><img src="http://cdn.wso2.com/wso2/newsletter/images/nl-2017/wso2-logo-transparent.png" border="0"/></a>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2" align="center" style="padding: 50px 50px 0px 50px;">
+                        <h1 style="padding-right: 0em; margin: 0; line-height: 40px; font-weight:300; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 1em;">
+                            Account Locked
+                        </h1>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="text-align: left; padding: 0px 50px;" valign="top">
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 3%;">
+                            Hi {{user.claim.givenname}},
+                        </p>
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 3%;">
+                            Please note that the account registered with the user name <b>{{user-name}}</b> has been locked. Please try again later.<br>
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="text-align: left; padding: 30px 50px 50px 50px" valign="top">
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #505050; text-align: left;">
+                            Thanks,<br/>WSO2 Identity Server Team
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2" align="center" style="padding: 20px 40px 40px 40px;" bgcolor="#f0f0f0">
+                        <p style="font-size: 12px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #777;">
+                            &copy; 2018
+                            <a href="http://wso2.com/" target="_blank" style="color: #777; text-decoration: none">WSO2</a>
+                            <br>
+                            787 Castro Street, Mountain View, CA 94041.
+                        </p>
+                    </td>
+                </tr>
+                </table>
+            </td>
+            </tr>
+        </table>]]></body>
+        <footer>---</footer>
+    </configuration>
+    <configuration type="accountLockAdmin" display="AccountLockAdmin" locale="en_US" emailContentType="text/html">
+        <subject>WSO2 - Your Account has been Locked</subject>
+        <body><![CDATA[<table align="center" cellpadding="0" cellspacing="0" border="0" width="100%"bgcolor="#f0f0f0">
+            <tr>
+            <td style="padding: 30px 30px 20px 30px;">
+                <table cellpadding="0" cellspacing="0" border="0" width="100%" bgcolor="#ffffff" style="max-width: 650px; margin: auto;">
+                <tr>
+                    <td colspan="2" align="center" style="background-color: #333; padding: 40px;">
+                        <a href="http://wso2.com/" target="_blank"><img src="http://cdn.wso2.com/wso2/newsletter/images/nl-2017/wso2-logo-transparent.png" border="0"/></a>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2" align="center" style="padding: 50px 50px 0px 50px;">
+                        <h1 style="padding-right: 0em; margin: 0; line-height: 40px; font-weight:300; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 1em;">
+                            Account Locked
+                        </h1>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="text-align: left; padding: 0px 50px;" valign="top">
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 3%;">
+                            Hi {{user.claim.givenname}},
+                        </p>
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 3%;">
+                            Please note that the account registered with the user name <b>{{user-name}}</b> has been locked by the administrator.<br>
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="text-align: left; padding: 30px 50px 50px 50px" valign="top">
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #505050; text-align: left;">
+                            Thanks,<br/>WSO2 Identity Server Team
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2" align="center" style="padding: 20px 40px 40px 40px;" bgcolor="#f0f0f0">
+                        <p style="font-size: 12px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #777;">
+                            &copy; 2018
+                            <a href="http://wso2.com/" target="_blank" style="color: #777; text-decoration: none">WSO2</a>
+                            <br>
+                            787 Castro Street, Mountain View, CA 94041.
+                        </p>
+                    </td>
+                </tr>
+                </table>
+            </td>
+            </tr>
+        </table>]]></body>
+        <footer>---</footer>
+    </configuration>
+    <configuration type="accountEnable" display="AccountEnable" locale="en_US" emailContentType="text/html">
+        <subject>WSO2 - Your Account has been Enabled</subject>
+        <body><![CDATA[<table align="center" cellpadding="0" cellspacing="0" border="0" width="100%"bgcolor="#f0f0f0">
+            <tr>
+            <td style="padding: 30px 30px 20px 30px;">
+                <table cellpadding="0" cellspacing="0" border="0" width="100%" bgcolor="#ffffff" style="max-width: 650px; margin: auto;">
+                <tr>
+                    <td colspan="2" align="center" style="background-color: #333; padding: 40px;">
+                        <a href="http://wso2.com/" target="_blank"><img src="http://cdn.wso2.com/wso2/newsletter/images/nl-2017/wso2-logo-transparent.png" border="0"/></a>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2" align="center" style="padding: 50px 50px 0px 50px;">
+                        <h1 style="padding-right: 0em; margin: 0; line-height: 40px; font-weight:300; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 1em;">
+                            Account Enabled
+                        </h1>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="text-align: left; padding: 0px 50px;" valign="top">
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 3%;">
+                            Hi {{user.claim.givenname}},
+                        </p>
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 3%;">
+                            Please note that the account registered with the user name <b>{{user-name}}</b> has been enabled.<br>
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="text-align: left; padding: 30px 50px 50px 50px" valign="top">
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #505050; text-align: left;">
+                            Thanks,<br/>WSO2 Identity Server Team
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2" align="center" style="padding: 20px 40px 40px 40px;" bgcolor="#f0f0f0">
+                        <p style="font-size: 12px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #777;">
+                            &copy; 2018
+                            <a href="http://wso2.com/" target="_blank" style="color: #777; text-decoration: none">WSO2</a>
+                            <br>
+                            787 Castro Street, Mountain View, CA 94041.
+                        </p>
+                    </td>
+                </tr>
+                </table>
+            </td>
+            </tr>
+        </table>]]></body>
+        <footer>---</footer>
+    </configuration>
+    <configuration type="accountDisable" display="AccountDisable" locale="en_US" emailContentType="text/html">
+        <subject>WSO2 - Your Account has been Disabled</subject>
+        <body><![CDATA[<table align="center" cellpadding="0" cellspacing="0" border="0" width="100%"bgcolor="#f0f0f0">
+            <tr>
+            <td style="padding: 30px 30px 20px 30px;">
+                <table cellpadding="0" cellspacing="0" border="0" width="100%" bgcolor="#ffffff" style="max-width: 650px; margin: auto;">
+                <tr>
+                    <td colspan="2" align="center" style="background-color: #333; padding: 40px;">
+                        <a href="http://wso2.com/" target="_blank"><img src="http://cdn.wso2.com/wso2/newsletter/images/nl-2017/wso2-logo-transparent.png" border="0"/></a>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2" align="center" style="padding: 50px 50px 0px 50px;">
+                        <h1 style="padding-right: 0em; margin: 0; line-height: 40px; font-weight:300; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 1em;">
+                            Account Disabled
+                        </h1>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="text-align: left; padding: 0px 50px;" valign="top">
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 3%;">
+                            Hi {{user.claim.givenname}},
+                        </p>
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 3%;">
+                            Please note that the account registered with the user name <b>{{user-name}}</b> has been disabled.<br>
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="text-align: left; padding: 30px 50px 50px 50px" valign="top">
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #505050; text-align: left;">
+                            Thanks,<br/>WSO2 Identity Server Team
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2" align="center" style="padding: 20px 40px 40px 40px;" bgcolor="#f0f0f0">
+                        <p style="font-size: 12px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #777;">
+                            &copy; 2018
+                            <a href="http://wso2.com/" target="_blank" style="color: #777; text-decoration: none">WSO2</a>
+                            <br>
+                            787 Castro Street, Mountain View, CA 94041.
+                        </p>
+                    </td>
+                </tr>
+                </table>
+            </td>
+            </tr>
+        </table>]]></body>
+        <footer>---</footer>
+    </configuration>
+    <configuration type="passwordResetSucess" display="passwordResetSucess" locale="en_US" emailContentType="text/html">
+        <subject>WSO2 - Password Reset Successful</subject>
+        <body><![CDATA[<table align="center" cellpadding="0" cellspacing="0" border="0" width="100%"bgcolor="#f0f0f0">
+            <tr>
+            <td style="padding: 30px 30px 20px 30px;">
+                <table cellpadding="0" cellspacing="0" border="0" width="100%" bgcolor="#ffffff" style="max-width: 650px; margin: auto;">
+                <tr>
+                    <td colspan="2" align="center" style="background-color: #333; padding: 40px;">
+                        <a href="http://wso2.com/" target="_blank"><img src="http://cdn.wso2.com/wso2/newsletter/images/nl-2017/wso2-logo-transparent.png" border="0"/></a>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2" align="center" style="padding: 50px 50px 0px 50px;">
+                        <h1 style="padding-right: 0em; margin: 0; line-height: 40px; font-weight:300; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 1em;">
+                            Password Reset Successful
+                        </h1>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="text-align: left; padding: 0px 50px;" valign="top">
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 3%;">
+                            Hi {{user-name}},
+                        </p>
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 3%;">
+                            Please note that your password has been successfully reset for the account <b>{{user-name}}</b>. <br>
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="text-align: left; padding: 30px 50px 50px 50px" valign="top">
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #505050; text-align: left;">
+                            Thanks,<br/>WSO2 Identity Server Team
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2" align="center" style="padding: 20px 40px 40px 40px;" bgcolor="#f0f0f0">
+                        <p style="font-size: 12px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #777;">
+                            &copy; 2018
+                            <a href="http://wso2.com/" target="_blank" style="color: #777; text-decoration: none">WSO2</a>
+                            <br>
+                            787 Castro Street, Mountain View, CA 94041.
+                        </p>
+                    </td>
+                </tr>
+                </table>
+            </td>
+            </tr>
+        </table>]]></body>
+        <footer>---</footer>
+    </configuration>
+    <configuration type="initiateRecovery" display="initiateRecovery" locale="en_US" emailContentType="text/html">
+        <subject>WSO2 - Password Reset Initiated</subject>
+        <body><![CDATA[<table align="center" cellpadding="0" cellspacing="0" border="0" width="100%"bgcolor="#f0f0f0">
+            <tr>
+            <td style="padding: 30px 30px 20px 30px;">
+                <table cellpadding="0" cellspacing="0" border="0" width="100%" bgcolor="#ffffff" style="max-width: 650px; margin: auto;">
+                <tr>
+                    <td colspan="2" align="center" style="background-color: #333; padding: 40px;">
+                        <a href="http://wso2.com/" target="_blank"><img src="http://cdn.wso2.com/wso2/newsletter/images/nl-2017/wso2-logo-transparent.png" border="0"/></a>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2" align="center" style="padding: 50px 50px 0px 50px;">
+                        <h1 style="padding-right: 0em; margin: 0; line-height: 40px; font-weight:300; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 1em;">
+                            Password Reset Initiated
+                        </h1>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="text-align: left; padding: 0px 50px;" valign="top">
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 3%;">
+                            Hi {{user.claim.givenname}},
+                        </p>
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 3%;">
+                            This is to notify that you have initiated to reset your password using security questions.<br>
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="text-align: left; padding: 30px 50px 50px 50px" valign="top">
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #505050; text-align: left;">
+                            Thanks,<br/>WSO2 Identity Server Team
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2" align="center" style="padding: 20px 40px 40px 40px;" bgcolor="#f0f0f0">
+                        <p style="font-size: 12px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #777;">
+                            &copy; 2018
+                            <a href="http://wso2.com/" target="_blank" style="color: #777; text-decoration: none">WSO2</a>
+                            <br>
+                            787 Castro Street, Mountain View, CA 94041.
+                        </p>
+                    </td>
+                </tr>
+                </table>
+            </td>
+            </tr>
+        </table>]]></body>
+        <footer>---</footer>
+    </configuration>
+    <configuration type="idleAccountReminder" display="idleAccountReminder" locale="en_US" emailContentType="text/html">
+        <subject>WSO2 - Account Inactive</subject>
+        <body><![CDATA[<table align="center" cellpadding="0" cellspacing="0" border="0" width="100%"bgcolor="#f0f0f0">
+            <tr>
+            <td style="padding: 30px 30px 20px 30px;">
+                <table cellpadding="0" cellspacing="0" border="0" width="100%" bgcolor="#ffffff" style="max-width: 650px; margin: auto;">
+                <tr>
+                    <td colspan="2" align="center" style="background-color: #333; padding: 40px;">
+                        <a href="http://wso2.com/" target="_blank"><img src="http://cdn.wso2.com/wso2/newsletter/images/nl-2017/wso2-logo-transparent.png" border="0"/></a>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2" align="center" style="padding: 50px 50px 0px 50px;">
+                        <h1 style="padding-right: 0em; margin: 0; line-height: 40px; font-weight:300; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 1em;">
+                            Account Inactive
+                        </h1>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="text-align: left; padding: 0px 50px;" valign="top">
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 3%;">
+                            Hi {{user.claim.givenname}},
+                        </p>
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 3%;">
+                            It looks as though you haven't signed in to your account for quite a while. Please sign in to your account if you'd like to keep your account active.<br>
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="text-align: left; padding: 30px 50px 50px 50px" valign="top">
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #505050; text-align: left;">
+                            Thanks,<br/>WSO2 Identity Server Team
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2" align="center" style="padding: 20px 40px 40px 40px;" bgcolor="#f0f0f0">
+                        <p style="font-size: 12px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #777;">
+                            &copy; 2018
+                            <a href="http://wso2.com/" target="_blank" style="color: #777; text-decoration: none">WSO2</a>
+                            <br>
+                            787 Castro Street, Mountain View, CA 94041.
+                        </p>
+                    </td>
+                </tr>
+                </table>
+            </td>
+            </tr>
+        </table>]]></body>
+        <footer>---</footer>
+    </configuration>
+    <configuration type="UnseenDeviceLogin" display="UnseenDeviceLogin" locale="en_US" emailContentType="text/html">
+        <subject>WSO2 - Login from a New Device</subject>
+        <body><![CDATA[<table align="center" cellpadding="0" cellspacing="0" border="0" width="100%"bgcolor="#f0f0f0">
+            <tr>
+            <td style="padding: 30px 30px 20px 30px;">
+                <table cellpadding="0" cellspacing="0" border="0" width="100%" bgcolor="#ffffff" style="max-width: 650px; margin: auto;">
+                <tr>
+                    <td colspan="2" align="center" style="background-color: #333; padding: 40px;">
+                        <a href="http://wso2.com/" target="_blank"><img src="http://cdn.wso2.com/wso2/newsletter/images/nl-2017/wso2-logo-transparent.png" border="0"/></a>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2" align="center" style="padding: 50px 50px 0px 50px;">
+                        <h1 style="padding-right: 0em; margin: 0; line-height: 40px; font-weight:300; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 1em;">
+                            Login from a New Device
+                        </h1>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="text-align: left; padding: 0px 50px;" valign="top">
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 3%;">
+                            Hi {{user.claim.givenname}},
+                        </p>
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 3%;">
+                            We detected a login to your account({{username}}) from a new device on {{login-time}}.<br>
+                            If it is not you, contact the administrator immediately.
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="text-align: left; padding: 30px 50px 50px 50px" valign="top">
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #505050; text-align: left;">
+                            Thanks,<br/>WSO2 Identity Server Team
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2" align="center" style="padding: 20px 40px 40px 40px;" bgcolor="#f0f0f0">
+                        <p style="font-size: 12px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #777;">
+                            &copy; 2018
+                            <a href="http://wso2.com/" target="_blank" style="color: #777; text-decoration: none">WSO2</a>
+                            <br>
+                            787 Castro Street, Mountain View, CA 94041.
+                        </p>
+                    </td>
+                </tr>
+                </table>
+            </td>
+            </tr>
+        </table>]]></body>
+        <footer>---</footer>
+    </configuration>
+</configurations>

--- a/components/email-mgt/org.wso2.carbon.email.mgt/src/test/resources/sms/sms-templates-admin-config.xml
+++ b/components/email-mgt/org.wso2.carbon.email.mgt/src/test/resources/sms/sms-templates-admin-config.xml
@@ -1,0 +1,41 @@
+<!--
+ ~ Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ ~
+ ~ WSO2 Inc. licenses this file to you under the Apache License,
+ ~ Version 2.0 (the "License"); you may not use this file except
+ ~ in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~ http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied.  See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+ -->
+
+<!--
+     Contains the SMS notification templates
+-->
+
+<configurations>
+    <configuration type="passwordResetSucess" display="passwordResetSucess" locale="en_US">
+        <body>Successful Password Reset</body>
+    </configuration>
+    <configuration type="accountconfirmation" display="accountconfirmation" locale="en_US">
+        <body>Your One-Time Password is : {{confirmation-code}}</body>
+    </configuration>
+    <configuration type="accountIdRecovery" display="accountIdRecovery" locale="en_US">
+        <body>
+            Hello, your user name is {{userstore-domain}}/{{user-name}}@{{tenant-domain}}
+        </body>
+    </configuration>
+    <configuration type="passwordReset" display="passwordReset" locale="en_US">
+        <body>Your One-Time Password : {{confirmation-code}}</body>
+    </configuration>
+    <configuration type="resendPasswordReset" display="resendPasswordReset" locale="en_US">
+        <body>Your One-Time Password : {{confirmation-code}}</body>
+    </configuration>
+</configurations>

--- a/components/email-mgt/org.wso2.carbon.email.mgt/src/test/resources/sms/sms-templates-admin-config.xml
+++ b/components/email-mgt/org.wso2.carbon.email.mgt/src/test/resources/sms/sms-templates-admin-config.xml
@@ -29,7 +29,7 @@
     </configuration>
     <configuration type="accountIdRecovery" display="accountIdRecovery" locale="en_US">
         <body>
-            Hello, your user name is {{userstore-domain}}/{{user-name}}@{{tenant-domain}}
+            Hello, your username is {{userstore-domain}}/{{user-name}}@{{tenant-domain}}
         </body>
     </configuration>
     <configuration type="passwordReset" display="passwordReset" locale="en_US">

--- a/features/org.wso2.carbon.email.mgt.server.feature/pom.xml
+++ b/features/org.wso2.carbon.email.mgt.server.feature/pom.xml
@@ -58,6 +58,7 @@
                                     <directory>resources</directory>
                                     <includes>
                                         <include>email-admin-config.xml</include>
+                                        <include>sms-templates-admin-config.xml</include>
                                         <include>p2.inf</include>
                                     </includes>
                                 </resource>

--- a/features/org.wso2.carbon.email.mgt.server.feature/resources/p2.inf
+++ b/features/org.wso2.carbon.email.mgt.server.feature/resources/p2.inf
@@ -1,2 +1,6 @@
 instructions.configure = \
+org.eclipse.equinox.p2.touchpoint.natives.mkdir(path:${installFolder}/../../../repository); \
+org.eclipse.equinox.p2.touchpoint.natives.mkdir(path:${installFolder}/../../../repository/conf); \
+org.eclipse.equinox.p2.touchpoint.natives.mkdir(path:${installFolder}/../../../repository/conf/sms); \
+org.eclipse.equinox.p2.touchpoint.natives.copy(source:${installFolder}/../features/org.wso2.carbon.email.mgt.server_${feature.version}/sms-templates-admin-config.xml,target:${installFolder}/../../conf/sms/sms-templates-admin-config.xml,overwrite:true);\
 org.eclipse.equinox.p2.touchpoint.natives.copy(source:${installFolder}/../features/org.wso2.carbon.email.mgt.server_${feature.version}/email-admin-config.xml,target:${installFolder}/../../conf/email/email-admin-config.xml,overwrite:true);\

--- a/features/org.wso2.carbon.email.mgt.server.feature/resources/sms-templates-admin-config.xml
+++ b/features/org.wso2.carbon.email.mgt.server.feature/resources/sms-templates-admin-config.xml
@@ -1,0 +1,41 @@
+<!--
+ ~ Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ ~
+ ~ WSO2 Inc. licenses this file to you under the Apache License,
+ ~ Version 2.0 (the "License"); you may not use this file except
+ ~ in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~ http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied.  See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+ -->
+
+<!--
+     Contains the SMS notification templates
+-->
+
+<configurations>
+    <configuration type="passwordResetSucess" display="passwordResetSucess" locale="en_US">
+        <body>Successful Password Reset</body>
+    </configuration>
+    <configuration type="accountconfirmation" display="accountconfirmation" locale="en_US">
+        <body>Your One-Time Password is : {{confirmation-code}}</body>
+    </configuration>
+    <configuration type="accountIdRecovery" display="accountIdRecovery" locale="en_US">
+        <body>
+            Hello, your user name is {{userstore-domain}}/{{user-name}}@{{tenant-domain}}
+        </body>
+    </configuration>
+    <configuration type="passwordReset" display="passwordReset" locale="en_US">
+        <body>Your One-Time Password : {{confirmation-code}}</body>
+    </configuration>
+    <configuration type="resendPasswordReset" display="resendPasswordReset" locale="en_US">
+        <body>Your One-Time Password : {{confirmation-code}}</body>
+    </configuration>
+</configurations>

--- a/pom.xml
+++ b/pom.xml
@@ -404,7 +404,7 @@
 
     <properties>
         <!--Identity Governance Version-->
-        <identity.governance.version>1.3.34</identity.governance.version>
+        <identity.governance.version>1.3.40-SNAPSHOT</identity.governance.version>
         <identity.governance.imp.pkg.version.range>[1.0.0, 2.0.0)</identity.governance.imp.pkg.version.range>
 
         <!--Identity Event Handler Email Version-->

--- a/pom.xml
+++ b/pom.xml
@@ -404,7 +404,7 @@
 
     <properties>
         <!--Identity Governance Version-->
-        <identity.governance.version>1.3.40-SNAPSHOT</identity.governance.version>
+        <identity.governance.version>1.3.44</identity.governance.version>
         <identity.governance.imp.pkg.version.range>[1.0.0, 2.0.0)</identity.governance.imp.pkg.version.range>
 
         <!--Identity Event Handler Email Version-->

--- a/pom.xml
+++ b/pom.xml
@@ -404,7 +404,7 @@
 
     <properties>
         <!--Identity Governance Version-->
-        <identity.governance.version>1.3.44</identity.governance.version>
+        <identity.governance.version>1.3.45</identity.governance.version>
         <identity.governance.imp.pkg.version.range>[1.0.0, 2.0.0)</identity.governance.imp.pkg.version.range>
 
         <!--Identity Event Handler Email Version-->


### PR DESCRIPTION
## Proposed changes in this pull request
Have introduced new set of APIs to add default SMS notifications during the server startup and tenant creation.

Reelated to Issue: https://github.com/wso2/product-is/issues/7006

## When should this PR be merged
The PR https://github.com/wso2-extensions/identity-governance/pull/350 should be merged first and then the governance version needs to be updated in the current PR.

## Tests
Unit tests have provided.
