### PR TITLE
Adding resend SMS confirmation template

### DIFF
--- a/components/email-mgt/org.wso2.carbon.email.mgt/src/test/resources/sms/sms-templates-admin-config.xml
+++ b/components/email-mgt/org.wso2.carbon.email.mgt/src/test/resources/sms/sms-templates-admin-config.xml
@@ -38,4 +38,7 @@
     <configuration type="resendPasswordReset" display="resendPasswordReset" locale="en_US">
         <body>Your One-Time Password : {{confirmation-code}}</body>
     </configuration>
+    <configuration type="resendAccountConfirmation" display="ResendAccountConfirmation" locale="en_US">
+        <body>Hello, Your One-Time Password is : {{confirmation-code}}</body>
+    </configuration>
 </configurations>


### PR DESCRIPTION
### Proposed changes in this pull request

Adding default SMS notification template for resending user self-registration confirmation.

Related PR: https://github.com/wso2-extensions/identity-governance/pull/364