### PR TITLE
Add email ContentType to TOTP template

### DIFF
--- a/features/org.wso2.carbon.email.mgt.server.feature/resources/email-admin-config.xml
+++ b/features/org.wso2.carbon.email.mgt.server.feature/resources/email-admin-config.xml
@@ -1663,7 +1663,7 @@
         </table>]]></body>
         <footer>---</footer>
     </configuration>
-    <configuration type="totp" display="TOTP" locale="en_US">
+    <configuration type="totp" display="TOTP" locale="en_US" emailContentType="text/html">
         <targetEpr></targetEpr>
         <subject>WSO2 Carbon - Time-Based One Time Password</subject>
         <body><![CDATA[<table align="center" cellpadding="0" cellspacing="0" border="0" width="100%" bgcolor="#f0f0f0">


### PR DESCRIPTION
### Proposed changes in this pull request

Add email content type to TOTP template due to open API validation exception thrown from integration tests. ContentType is a required property of email template schema in API.