### PR TITLE
Add url to append user tenant in the email template

### DIFF
--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/NotificationConstants.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/NotificationConstants.java
@@ -74,7 +74,7 @@ public class NotificationConstants {
 
         public static final String CARBON_PRODUCT_URL_TEMPLATE_PLACEHOLDER = "carbon.product-url";
         public static final String CARBON_PRODUCT_URL_WITH_USER_TENANT_TEMPLATE_PLACEHOLDER
-                = "product-url-with-tenant";
+                = "product-url-with-user-tenant";
 
     }
 

--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/NotificationConstants.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/NotificationConstants.java
@@ -73,6 +73,8 @@ public class NotificationConstants {
         public static final String ARBITRARY_FOOTER = "footer";
 
         public static final String CARBON_PRODUCT_URL_TEMPLATE_PLACEHOLDER = "carbon.product-url";
+        public static final String CARBON_PRODUCT_URL_WITH_USER_TENANT_TEMPLATE_PLACEHOLDER
+                = "product-url-with-tenant";
 
     }
 

--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/util/NotificationUtil.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/util/NotificationUtil.java
@@ -62,6 +62,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static org.wso2.carbon.identity.event.handler.notification.NotificationConstants.EmailNotification.CARBON_PRODUCT_URL_TEMPLATE_PLACEHOLDER;
+import static org.wso2.carbon.identity.event.handler.notification.NotificationConstants.EmailNotification.CARBON_PRODUCT_URL_WITH_USER_TENANT_TEMPLATE_PLACEHOLDER;
 
 public class NotificationUtil {
 
@@ -181,13 +182,21 @@ public class NotificationUtil {
         }
         // Building the server url.
         String serverURL;
+        String carbonUrlWithUserTenant;
         try {
             serverURL = ServiceURLBuilder.create().build().getAbsolutePublicURL();
+            if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
+                carbonUrlWithUserTenant = ServiceURLBuilder.create().build().getAbsolutePublicUrlWithoutPath() + "/t/"
+                         + placeHolderData.get("tenant-domain");
+            } else {
+                carbonUrlWithUserTenant = ServiceURLBuilder.create().build().getAbsolutePublicUrlWithoutPath();
+            }
         } catch (URLBuilderException e) {
             throw NotificationRuntimeException.error("Error while building the server url.", e);
         }
 
         placeHolderData.put(CARBON_PRODUCT_URL_TEMPLATE_PLACEHOLDER, serverURL);
+        placeHolderData.put(CARBON_PRODUCT_URL_WITH_USER_TENANT_TEMPLATE_PLACEHOLDER, carbonUrlWithUserTenant);
         return placeHolderData;
     }
 

--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/util/NotificationUtil.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/util/NotificationUtil.java
@@ -185,11 +185,10 @@ public class NotificationUtil {
         String carbonUrlWithUserTenant;
         try {
             serverURL = ServiceURLBuilder.create().build().getAbsolutePublicURL();
+            carbonUrlWithUserTenant = ServiceURLBuilder.create().build().getAbsolutePublicUrlWithoutPath();
             if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
-                carbonUrlWithUserTenant = ServiceURLBuilder.create().build().getAbsolutePublicUrlWithoutPath() + "/t/"
-                         + placeHolderData.get("tenant-domain");
-            } else {
-                carbonUrlWithUserTenant = ServiceURLBuilder.create().build().getAbsolutePublicUrlWithoutPath();
+                carbonUrlWithUserTenant = ServiceURLBuilder.create().build().getAbsolutePublicUrlWithoutPath() + "/t" +
+                        "/" + placeHolderData.get("tenant-domain");
             }
         } catch (URLBuilderException e) {
             throw NotificationRuntimeException.error("Error while building the server url.", e);

--- a/features/org.wso2.carbon.email.mgt.server.feature/resources/email-admin-config.xml
+++ b/features/org.wso2.carbon.email.mgt.server.feature/resources/email-admin-config.xml
@@ -1756,7 +1756,7 @@
                         <table align="left" cellpadding="0" cellspacing="0" border="0" style="border-radius: 4px; background-color: #ff5000;">
                             <tr>
                                 <td style="border-radius: 6px;  padding: 14px 0px;">
-                                    <a href="{{product-url-with-tenant}}/accountrecoveryendpoint/confirmrecovery.do?confirmation={{confirmation-code}}&amp;userstoredomain={{userstore-domain}}&amp;username={{url:user-name}}&amp;tenantdomain={{tenant-domain}}&amp;callback={{carbon.product-url}}/console"
+                                    <a href="{{product-url-with-user-tenant}}/accountrecoveryendpoint/confirmrecovery.do?confirmation={{confirmation-code}}&amp;userstoredomain={{userstore-domain}}&amp;username={{url:user-name}}&amp;tenantdomain={{tenant-domain}}&amp;callback={{carbon.product-url}}/console"
                                        target="_blank" style="width: 230px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif;  font-size: 18px; line-height: 21px; font-weight: 600; color: #fff; text-decoration: none; background-color: #ff5000; text-align: center; display: inline-block;cursor: pointer;">Set Password</a>
                                 </td>
                             </tr>
@@ -1768,8 +1768,8 @@
                         <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #505050; text-align: left;">
                             If clicking the button doesn't seem to work, you can copy and paste the following link into your browser. <br/>
                             <a style="word-break: break-all; color: #ff5000; font-size: 14px" target="_blank"
-                               href="{{product-url-with-tenant}}/accountrecoveryendpoint/confirmrecovery.do?confirmation={{confirmation-code}}&amp;userstoredomain={{userstore-domain}}&amp;username={{url:user-name}}&amp;tenantdomain={{tenant-domain}}&amp;callback={{carbon.product-url}}/console">
-                                {{product-url-with-tenant}}/accountrecoveryendpoint/confirmrecovery.do?confirmation={{confirmation-code}}&amp;userstoredomain={{userstore-domain}}&amp;username={{url:user-name}}&amp;tenantdomain={{tenant-domain}}&amp;callback={{carbon.product-url}}/console</a>
+                               href="{{product-url-with-user-tenant}}/accountrecoveryendpoint/confirmrecovery.do?confirmation={{confirmation-code}}&amp;userstoredomain={{userstore-domain}}&amp;username={{url:user-name}}&amp;tenantdomain={{tenant-domain}}&amp;callback={{carbon.product-url}}/console">
+                                {{product-url-with-user-tenant}}/accountrecoveryendpoint/confirmrecovery.do?confirmation={{confirmation-code}}&amp;userstoredomain={{userstore-domain}}&amp;username={{url:user-name}}&amp;tenantdomain={{tenant-domain}}&amp;callback={{carbon.product-url}}/console</a>
                         </p>
                     </td>
                 </tr>

--- a/features/org.wso2.carbon.email.mgt.server.feature/resources/email-admin-config.xml
+++ b/features/org.wso2.carbon.email.mgt.server.feature/resources/email-admin-config.xml
@@ -1756,7 +1756,7 @@
                         <table align="left" cellpadding="0" cellspacing="0" border="0" style="border-radius: 4px; background-color: #ff5000;">
                             <tr>
                                 <td style="border-radius: 6px;  padding: 14px 0px;">
-                                    <a href="{{carbon.product-url}}/accountrecoveryendpoint/confirmrecovery.do?confirmation={{confirmation-code}}&amp;userstoredomain={{userstore-domain}}&amp;username={{url:user-name}}&amp;tenantdomain={{tenant-domain}}&amp;callback={{carbon.product-url}}/t/{{tenant-domain}}/admin-portal"
+                                    <a href="{{product-url-with-tenant}}/accountrecoveryendpoint/confirmrecovery.do?confirmation={{confirmation-code}}&amp;userstoredomain={{userstore-domain}}&amp;username={{url:user-name}}&amp;tenantdomain={{tenant-domain}}&amp;callback={{carbon.product-url}}/console"
                                        target="_blank" style="width: 230px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif;  font-size: 18px; line-height: 21px; font-weight: 600; color: #fff; text-decoration: none; background-color: #ff5000; text-align: center; display: inline-block;cursor: pointer;">Set Password</a>
                                 </td>
                             </tr>
@@ -1768,8 +1768,8 @@
                         <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #505050; text-align: left;">
                             If clicking the button doesn't seem to work, you can copy and paste the following link into your browser. <br/>
                             <a style="word-break: break-all; color: #ff5000; font-size: 14px" target="_blank"
-                               href="{{carbon.product-url}}/accountrecoveryendpoint/confirmrecovery.do?confirmation={{confirmation-code}}&amp;userstoredomain={{userstore-domain}}&amp;username={{url:user-name}}&amp;tenantdomain={{tenant-domain}}&amp;callback={{carbon.product-url}}/t/{{tenant-domain}}/admin-portal">
-                                {{carbon.product-url}}/accountrecoveryendpoint/confirmrecovery.do?confirmation={{confirmation-code}}&amp;userstoredomain={{userstore-domain}}&amp;username={{url:user-name}}&amp;tenantdomain={{tenant-domain}}&amp;callback={{carbon.product-url}}/t/{{tenant-domain}}/admin-portal</a>
+                               href="{{product-url-with-tenant}}/accountrecoveryendpoint/confirmrecovery.do?confirmation={{confirmation-code}}&amp;userstoredomain={{userstore-domain}}&amp;username={{url:user-name}}&amp;tenantdomain={{tenant-domain}}&amp;callback={{carbon.product-url}}/console">
+                                {{product-url-with-tenant}}/accountrecoveryendpoint/confirmrecovery.do?confirmation={{confirmation-code}}&amp;userstoredomain={{userstore-domain}}&amp;username={{url:user-name}}&amp;tenantdomain={{tenant-domain}}&amp;callback={{carbon.product-url}}/console</a>
                         </p>
                     </td>
                 </tr>

--- a/pom.xml
+++ b/pom.xml
@@ -430,7 +430,7 @@
         <carbon.commons.imp.pkg.version>[4.7.11, 5.0.0)</carbon.commons.imp.pkg.version>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.17.54</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.19.41</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.14.67, 6.0.0)</carbon.identity.framework.imp.pkg.version.range>
 
         <!--Carbon Analytics Common Version-->

--- a/pom.xml
+++ b/pom.xml
@@ -430,7 +430,7 @@
         <carbon.commons.imp.pkg.version>[4.7.11, 5.0.0)</carbon.commons.imp.pkg.version>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.19.41</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.19.52</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.14.67, 6.0.0)</carbon.identity.framework.imp.pkg.version.range>
 
         <!--Carbon Analytics Common Version-->


### PR DESCRIPTION
### Proposed changes in this pull request

Depends on https://github.com/wso2/carbon-identity-framework/pull/3420
As a part of https://github.com/wso2/product-is/issues/11380

In tenantRgistration flow, user's tenant is different from the context tenant. In the context the tenant will be carbon.super, since the tenant creation happens in the super tenant. 