### PR TITLE
Update accountLockFailedAttempt email template with account lock duration in minutes

### DIFF
--- a/features/org.wso2.carbon.email.mgt.server.feature/resources/email-admin-config.xml
+++ b/features/org.wso2.carbon.email.mgt.server.feature/resources/email-admin-config.xml
@@ -1146,7 +1146,7 @@
                             Hi {{user.claim.givenname}},
                         </p>
                         <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 3%;">
-                            Please note that the account registered with the user name <b>{{user-name}}</b> has been locked. Please try again later.<br>
+                            Please note that the account registered with the user name <b>{{user-name}}</b> has been locked. Please try again in {{lock-duration}} minutes.<br>
                         </p>
                     </td>
                 </tr>


### PR DESCRIPTION
### Proposed changes in this pull request
 The existing email template used to send a mail once the account is locked when maximum failed login attempts are reached does not contain the information about how long the account will be locked fr. This fix is to add that information to the email.
