### PR TITLE
IdentityEventException thrown for missing email claim when sending email notifications

### DIFF
--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/util/NotificationUtil.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/util/NotificationUtil.java
@@ -318,8 +318,8 @@ public class NotificationUtil {
                 sendTo = userClaims.get(NotificationConstants.EmailNotification.CLAIM_URI_EMAIL);
             }
             if (StringUtils.isEmpty(sendTo)) {
-                throw NotificationRuntimeException.error(
-                        "Email notification sending failed. Sending email address is not configured for the user.");
+                throw new IdentityEventException("Email notification sending failed. " +
+                        "Sending email address is not configured for the user.");
             }
         }
 


### PR DESCRIPTION
## Purpose
> Resolves https://github.com/wso2/product-is/issues/12782
> IdentityEventExceptions are caught and handled higher up the call stack unlike RuntimeExceptions. Hence, this would not break the email sending flow in case the email claim is absent for a particular user.