### PR TITLE
Fix email mime type option

### DIFF
--- a/components/email-mgt/org.wso2.carbon.email.mgt.ui/src/main/resources/web/email-mgt/email-template-config.jsp
+++ b/components/email-mgt/org.wso2.carbon.email.mgt.ui/src/main/resources/web/email-mgt/email-template-config.jsp
@@ -300,13 +300,18 @@
                                 <%
                                     for (String currentType : emailContentTypeArr) {
                                         String currentSelectedAttr = "";
-                                        if (currentType.equals(emailContentType0)) {
+                                        if (StringUtils.contains(emailContentType0, currentType)) {
                                             currentSelectedAttr = "selected=\"selected\"";
-                                        }
                                 %>
-                                <option <%=Encode.forHtmlAttribute(currentSelectedAttr)%>><%=Encode.forHtmlContent(currentType)%>
+                                <option <%=Encode.forHtmlAttribute(currentSelectedAttr)%>> <%=Encode.forHtmlContent(currentType)%>
                                 </option>
                                 <%
+                                        } else {
+                                %>
+                                <option> <%=Encode.forHtmlContent(currentType)%>
+                                </option>
+                                <%
+                                        }
                                     }
                                 %>
                             </select></td>


### PR DESCRIPTION
$sub

Public Issue: [12870](https://github.com/wso2/product-is/issues/12870)

Solution: 

1. Instead of using **equals** we are going  to use stringutils **contains** cause emailContentType0 vaue is **text/html; charset=UTF-8** or **text/plain; charset=UTF-8**


2. HTML Attribute Selected=Selected and Selected="" will select the option, so for the selected item we keep the selected attribute and for nonselected item we remove the attribute.

Tests Performed:

1. UI test
2. Rest API call to verify the change affect any existing internal modifications.

Fix:
![fix](https://user-images.githubusercontent.com/25488962/147466239-b628ea71-f22a-4ddb-9fe8-41fd88a16ea4.gif)
