### PR TITLE
Template current year to be used in email templates

### DIFF
--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/NotificationHandler.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/NotificationHandler.java
@@ -37,6 +37,7 @@ import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Calendar;
 
 /**
  * This is the Email and SMS Notification Handler which connected to the direct CEP stream.
@@ -63,6 +64,8 @@ public class NotificationHandler extends DefaultNotificationHandler {
                 arbitraryDataMap.put(entry.getKey(), (String) entry.getValue());
             }
         }
+        int currentYear = Calendar.getInstance().get(Calendar.YEAR);
+        arbitraryDataMap.put("current-year", String.valueOf(currentYear));
         Notification notification = NotificationUtil.buildNotification(event, arbitraryDataMap);
 
         //Stream definition will be read from the the identity-even.properties file as a property of the subscription

--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/NotificationHandler.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/NotificationHandler.java
@@ -37,7 +37,6 @@ import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Calendar;
 
 /**
  * This is the Email and SMS Notification Handler which connected to the direct CEP stream.
@@ -64,8 +63,6 @@ public class NotificationHandler extends DefaultNotificationHandler {
                 arbitraryDataMap.put(entry.getKey(), (String) entry.getValue());
             }
         }
-        int currentYear = Calendar.getInstance().get(Calendar.YEAR);
-        arbitraryDataMap.put("current-year", String.valueOf(currentYear));
         Notification notification = NotificationUtil.buildNotification(event, arbitraryDataMap);
 
         //Stream definition will be read from the the identity-even.properties file as a property of the subscription

--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/util/NotificationUtil.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/util/NotificationUtil.java
@@ -332,7 +332,7 @@ public class NotificationUtil {
             throw NotificationRuntimeException.error(message, e);
         }
 
-        // this is added to change the copyright year in the email templates dynamically.
+        // This is added to change the copyright year in the email templates dynamically.
         int currentYear = Calendar.getInstance().get(Calendar.YEAR);
         placeHolderData.put("current-year", String.valueOf(currentYear));
 

--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/util/NotificationUtil.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/util/NotificationUtil.java
@@ -53,6 +53,7 @@ import org.wso2.carbon.user.core.service.RealmService;
 
 import javax.xml.namespace.QName;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -330,6 +331,10 @@ public class NotificationUtil {
             String message = "Error when retrieving template from tenant registry.";
             throw NotificationRuntimeException.error(message, e);
         }
+
+        //this is added to change the copyright year in the email templates dynamically
+        int currentYear = Calendar.getInstance().get(Calendar.YEAR);
+        placeHolderData.put("current-year", String.valueOf(currentYear));
 
         NotificationUtil.getPlaceholderValues(emailTemplate, placeHolderData, userClaims);
 

--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/util/NotificationUtil.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/util/NotificationUtil.java
@@ -332,7 +332,7 @@ public class NotificationUtil {
             throw NotificationRuntimeException.error(message, e);
         }
 
-        //this is added to change the copyright year in the email templates dynamically
+        // this is added to change the copyright year in the email templates dynamically.
         int currentYear = Calendar.getInstance().get(Calendar.YEAR);
         placeHolderData.put("current-year", String.valueOf(currentYear));
 


### PR DESCRIPTION
The current year was templated so that copyright year in the email templates will be updated dynamically.