### PR TITLE
Encode email body and footer before form submission in add/update email templates

### DIFF
--- a/components/email-mgt/org.wso2.carbon.email.mgt.ui/src/main/resources/web/email-mgt/email-template-add-finish-ajaxprocessor.jsp
+++ b/components/email-mgt/org.wso2.carbon.email.mgt.ui/src/main/resources/web/email-mgt/email-template-add-finish-ajaxprocessor.jsp
@@ -15,6 +15,8 @@
 ~ specific language governing permissions and limitations
 ~ under the License.
 -->
+<%@page import="java.nio.charset.StandardCharsets"%>
+<%@page import="java.util.Base64"%>
 <%@page import="org.apache.axis2.context.ConfigurationContext" %>
 <%@page import="org.apache.commons.lang.StringUtils" %>
 <%@ page import="org.wso2.carbon.CarbonConstants" %>
@@ -38,7 +40,9 @@
 
     String emailSubject = request.getParameter("emailSubject");
     String emailBody = request.getParameter("emailBody");
+    emailBody = new String(Base64.getDecoder().decode(emailBody), StandardCharsets.UTF_8);
     String emailFooter = request.getParameter("emailFooter");
+    emailFooter = new String(Base64.getDecoder().decode(emailFooter), StandardCharsets.UTF_8);
 
     EmailTemplate templateAdded = new EmailTemplate();
     if (StringUtils.isNotBlank(emailTypeDisplayName)) {

--- a/components/email-mgt/org.wso2.carbon.email.mgt.ui/src/main/resources/web/email-mgt/email-template-add.jsp
+++ b/components/email-mgt/org.wso2.carbon.email.mgt.ui/src/main/resources/web/email-mgt/email-template-add.jsp
@@ -141,6 +141,12 @@
                         CARBON.showWarningDialog('<fmt:message key="email.template.footer.is.required"/>');
                         return false;
                     }
+
+                    var emailBody = document.getElementsByName("emailBody")[0].value;
+                    document.getElementsByName("emailBody")[0].value = btoa(emailBody);
+                    var emailFooter = document.getElementsByName("emailFooter")[0].value;
+                    document.getElementsByName("emailFooter")[0].value = btoa(emailFooter);
+
                     document.addemailtemplate.submit();
                 }
 

--- a/components/email-mgt/org.wso2.carbon.email.mgt.ui/src/main/resources/web/email-mgt/email-template-config-finish-ajaxprocessor.jsp
+++ b/components/email-mgt/org.wso2.carbon.email.mgt.ui/src/main/resources/web/email-mgt/email-template-config-finish-ajaxprocessor.jsp
@@ -18,6 +18,8 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 <%@ taglib uri="http://wso2.org/projects/carbon/taglibs/carbontags.jar" prefix="carbon" %>
+<%@page import="java.nio.charset.StandardCharsets"%>
+<%@page import="java.util.Base64"%>
 <%@page import="org.apache.axis2.context.ConfigurationContext" %>
 <%@page import="org.apache.commons.lang.StringUtils" %>
 <%@page import="org.wso2.carbon.CarbonConstants" %>
@@ -41,7 +43,9 @@
 
     String emailSubject = request.getParameter("emailSubject");
     String emailBody = request.getParameter("emailBody");
+    emailBody = new String(Base64.getDecoder().decode(emailBody), StandardCharsets.UTF_8);
     String emailFooter = request.getParameter("emailFooter");
+    emailFooter = new String(Base64.getDecoder().decode(emailFooter), StandardCharsets.UTF_8);
 
     // params to handle deleting templates
     boolean deleteTemplate = false;

--- a/components/email-mgt/org.wso2.carbon.email.mgt.ui/src/main/resources/web/email-mgt/email-template-config.jsp
+++ b/components/email-mgt/org.wso2.carbon.email.mgt.ui/src/main/resources/web/email-mgt/email-template-config.jsp
@@ -137,6 +137,12 @@
                         CARBON.showWarningDialog('<fmt:message key="email.template.footer.is.required"/>');
                         return false;
                     }
+
+                    var emailBody = document.getElementsByName("emailBody")[0].value;
+                    document.getElementsByName("emailBody")[0].value = btoa(emailBody);
+                    var emailFooter = document.getElementsByName("emailFooter")[0].value;
+                    document.getElementsByName("emailFooter")[0].value = btoa(emailFooter);
+
                     document.templateForm.submit();
                 }
 


### PR DESCRIPTION
Resolves part of [product-is #13987](https://github.com/wso2/product-is/issues/13987)

Fixes the issue mentioned in product-is #13987 for 

- Email body and email footer in add and update email templates

by base64 encoding the provided email body and footer values