### PR TITLE
Adding null check for claim values

### DIFF
--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/DefaultNotificationHandler.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/DefaultNotificationHandler.java
@@ -174,7 +174,9 @@ public class DefaultNotificationHandler extends AbstractEventHandler {
         for (String key : keys) {
             String claim = arbitraryDataClaims.get(key);
             String value = userClaims.get(claim);
-            arbitraryDataMap.put(key, value);
+            if (value != null) {
+                arbitraryDataMap.put(key, value);
+            }
         }
         Map<String, String> arbitraryDataFromProperties = getArbitraryDataFromProperties(event);
         arbitraryDataMap.putAll(arbitraryDataFromProperties);


### PR DESCRIPTION
### Proposed changes in this pull request

In the sms-otp flow when the user mobile number has not added, the mobile claim is null.
In that case  sms-otp authenticator promts to enter user mobile in the login flow and send it as a event property to default notification handler. But according to previous logic as the mobile claim is null, value of the `arbitraryDataMap` is replaced with null. Therefore added a null check before adding the claim value.