### PR TITLE
Fix email content type with language change

### DIFF
--- a/components/email-mgt/org.wso2.carbon.email.mgt.ui/src/main/resources/web/email-mgt/email-template-config.jsp
+++ b/components/email-mgt/org.wso2.carbon.email.mgt.ui/src/main/resources/web/email-mgt/email-template-config.jsp
@@ -115,6 +115,10 @@
         <div id="workArea">
 
             <script type="text/javascript">
+                const emailContentTypeMap = new Map([
+                    ["text/plain; charset=UTF-8", "text/plain"],
+                    ["text/html; charset=UTF-8", "text/html"]
+                ]);
 
                 function validate() {
                     var value = document.getElementsByName("emailSubject")[0].value;
@@ -152,7 +156,7 @@
                     jQuery('#emailBody').val($selectedOption.attr('data-body'));
                     jQuery('#emailFooter').val($selectedOption.attr('data-footer'));
                     jQuery('#templateName').val($selectedOption.attr('data-templateName'));
-                    jQuery('#emailContentType').val($selectedOption.attr('data-emailContentType'));
+                    jQuery('#emailContentType').val(emailContentTypeMap.get($selectedOption.attr('data-emailContentType')));
                 }
 
 


### PR DESCRIPTION
## Description

Fix the issue when selecting an email template language from the drop-down list from Management Console > Manage > Email Templates, the email content type is set to null.

## Related issue
- https://github.com/wso2/product-is/issues/14832