### PR TITLE
Fix encoding and decoding email templates with non English special characters

### DIFF
--- a/components/email-mgt/org.wso2.carbon.email.mgt.ui/src/main/resources/web/email-mgt/email-template-add-finish-ajaxprocessor.jsp
+++ b/components/email-mgt/org.wso2.carbon.email.mgt.ui/src/main/resources/web/email-mgt/email-template-add-finish-ajaxprocessor.jsp
@@ -41,7 +41,7 @@
 
     String emailSubject = request.getParameter("emailSubject");
     String emailBody = request.getParameter("emailBody");
-    emailBody =  URLDecoder.decode(new String(Base64.getDecoder().decode(emailBody), StandardCharsets.UTF_8));
+    emailBody = URLDecoder.decode(new String(Base64.getDecoder().decode(emailBody), StandardCharsets.UTF_8));
     String emailFooter = request.getParameter("emailFooter");
     emailFooter = URLDecoder.decode(new String(Base64.getDecoder().decode(emailFooter), StandardCharsets.UTF_8));
 

--- a/components/email-mgt/org.wso2.carbon.email.mgt.ui/src/main/resources/web/email-mgt/email-template-add-finish-ajaxprocessor.jsp
+++ b/components/email-mgt/org.wso2.carbon.email.mgt.ui/src/main/resources/web/email-mgt/email-template-add-finish-ajaxprocessor.jsp
@@ -17,6 +17,7 @@
 -->
 <%@page import="java.nio.charset.StandardCharsets"%>
 <%@page import="java.util.Base64"%>
+<%@page import="java.net.URLDecoder"%>
 <%@page import="org.apache.axis2.context.ConfigurationContext" %>
 <%@page import="org.apache.commons.lang.StringUtils" %>
 <%@ page import="org.wso2.carbon.CarbonConstants" %>
@@ -40,9 +41,9 @@
 
     String emailSubject = request.getParameter("emailSubject");
     String emailBody = request.getParameter("emailBody");
-    emailBody = new String(Base64.getDecoder().decode(emailBody), StandardCharsets.UTF_8);
+    emailBody =  URLDecoder.decode(new String(Base64.getDecoder().decode(emailBody), StandardCharsets.UTF_8));
     String emailFooter = request.getParameter("emailFooter");
-    emailFooter = new String(Base64.getDecoder().decode(emailFooter), StandardCharsets.UTF_8);
+    emailFooter = URLDecoder.decode(new String(Base64.getDecoder().decode(emailFooter), StandardCharsets.UTF_8));
 
     EmailTemplate templateAdded = new EmailTemplate();
     if (StringUtils.isNotBlank(emailTypeDisplayName)) {

--- a/components/email-mgt/org.wso2.carbon.email.mgt.ui/src/main/resources/web/email-mgt/email-template-add.jsp
+++ b/components/email-mgt/org.wso2.carbon.email.mgt.ui/src/main/resources/web/email-mgt/email-template-add.jsp
@@ -143,9 +143,9 @@
                     }
 
                     var emailBody = document.getElementsByName("emailBody")[0].value;
-                    document.getElementsByName("emailBody")[0].value = btoa(emailBody);
+                    document.getElementsByName("emailBody")[0].value = btoa(encodeURIComponent(emailBody));
                     var emailFooter = document.getElementsByName("emailFooter")[0].value;
-                    document.getElementsByName("emailFooter")[0].value = btoa(emailFooter);
+                    document.getElementsByName("emailFooter")[0].value = btoa(encodeURIComponent(emailFooter));
 
                     document.addemailtemplate.submit();
                 }

--- a/components/email-mgt/org.wso2.carbon.email.mgt.ui/src/main/resources/web/email-mgt/email-template-config-finish-ajaxprocessor.jsp
+++ b/components/email-mgt/org.wso2.carbon.email.mgt.ui/src/main/resources/web/email-mgt/email-template-config-finish-ajaxprocessor.jsp
@@ -20,6 +20,7 @@
 <%@ taglib uri="http://wso2.org/projects/carbon/taglibs/carbontags.jar" prefix="carbon" %>
 <%@page import="java.nio.charset.StandardCharsets"%>
 <%@page import="java.util.Base64"%>
+<%@page import="java.net.URLDecoder"%>
 <%@page import="org.apache.axis2.context.ConfigurationContext" %>
 <%@page import="org.apache.commons.lang.StringUtils" %>
 <%@page import="org.wso2.carbon.CarbonConstants" %>
@@ -43,9 +44,7 @@
 
     String emailSubject = request.getParameter("emailSubject");
     String emailBody = request.getParameter("emailBody");
-    emailBody = new String(Base64.getDecoder().decode(emailBody), StandardCharsets.UTF_8);
     String emailFooter = request.getParameter("emailFooter");
-    emailFooter = new String(Base64.getDecoder().decode(emailFooter), StandardCharsets.UTF_8);
 
     // params to handle deleting templates
     boolean deleteTemplate = false;
@@ -59,6 +58,10 @@
 
     EmailTemplate templateChanged = new EmailTemplate();
     if (!deleteTemplate) {
+        //decode the  emailBody and emailFooter
+        emailBody =  URLDecoder.decode(new String(Base64.getDecoder().decode(emailBody), StandardCharsets.UTF_8));
+        emailFooter = URLDecoder.decode(new String(Base64.getDecoder().decode(emailFooter), StandardCharsets.UTF_8));
+
         if (StringUtils.isNotBlank(templateDisplayName)) {
             templateChanged.setTemplateDisplayName(templateDisplayName);
         }

--- a/components/email-mgt/org.wso2.carbon.email.mgt.ui/src/main/resources/web/email-mgt/email-template-config-finish-ajaxprocessor.jsp
+++ b/components/email-mgt/org.wso2.carbon.email.mgt.ui/src/main/resources/web/email-mgt/email-template-config-finish-ajaxprocessor.jsp
@@ -58,8 +58,8 @@
 
     EmailTemplate templateChanged = new EmailTemplate();
     if (!deleteTemplate) {
-        //decode the  emailBody and emailFooter
-        emailBody =  URLDecoder.decode(new String(Base64.getDecoder().decode(emailBody), StandardCharsets.UTF_8));
+        // Decode emailBody and emailFooter.
+        emailBody = URLDecoder.decode(new String(Base64.getDecoder().decode(emailBody), StandardCharsets.UTF_8));
         emailFooter = URLDecoder.decode(new String(Base64.getDecoder().decode(emailFooter), StandardCharsets.UTF_8));
 
         if (StringUtils.isNotBlank(templateDisplayName)) {

--- a/components/email-mgt/org.wso2.carbon.email.mgt.ui/src/main/resources/web/email-mgt/email-template-config.jsp
+++ b/components/email-mgt/org.wso2.carbon.email.mgt.ui/src/main/resources/web/email-mgt/email-template-config.jsp
@@ -139,9 +139,9 @@
                     }
 
                     var emailBody = document.getElementsByName("emailBody")[0].value;
-                    document.getElementsByName("emailBody")[0].value = btoa(emailBody);
+                    document.getElementsByName("emailBody")[0].value = btoa(encodeURIComponent(emailBody));
                     var emailFooter = document.getElementsByName("emailFooter")[0].value;
-                    document.getElementsByName("emailFooter")[0].value = btoa(emailFooter);
+                    document.getElementsByName("emailFooter")[0].value = btoa(encodeURIComponent(emailFooter));
 
                     document.templateForm.submit();
                 }


### PR DESCRIPTION
### Proposed changes in this pull request
- Change the encoding and decoding of email body and footer because current encoding is not supported for some non English special characters
- Fix the Email templates and Email template type issue
  - Previously try to decode the email body and footer which is not encoded when deleting
  - Change the code to avoid decoding the email body and the footer when delete action is performed

### Related issue
-  Resolves https://github.com/wso2/product-is/issues/14861
