### PR TITLE
Support organization-name placeholder

### DIFF
--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/pom.xml
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/pom.xml
@@ -78,6 +78,10 @@
             <artifactId>org.wso2.carbon.email.mgt</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.carbon.identity.branding.preference.management</groupId>
             <artifactId>org.wso2.carbon.identity.branding.preference.management.core</artifactId>
             <scope>provided</scope>
@@ -172,7 +176,10 @@
                             org.wso2.carbon.databridge.commons.*; version="${carbon.analytics.common.version.range}",
                             org.wso2.carbon.email.mgt.*; version="${identity.event.handler.notification.imp.pkg.version.range}",
                             org.wso2.carbon.identity.governance.*; version="${identity.governance.imp.pkg.version.range}",
-                            org.wso2.carbon.identity.branding.preference.management.core.*; version="${identity.branding.preference.management.version}"
+                            org.wso2.carbon.identity.branding.preference.management.core.*; version="${identity.branding.preference.management.version}",
+                            org.wso2.carbon.identity.organization.management.service;version="${org.wso2.identity.organization.mgt.core.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.organization.management.service.constant;version="${org.wso2.identity.organization.mgt.core.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.organization.management.service.exception;version="${org.wso2.identity.organization.mgt.core.imp.pkg.version.range}",
                         </Import-Package>
                     </instructions>
                 </configuration>

--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/NotificationConstants.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/NotificationConstants.java
@@ -79,6 +79,7 @@ public class NotificationConstants {
         public static final String AUTHENTICATION_ENDPOINT_PLACEHOLDER = "authentication.endpoint-url";
         public static final String CARBON_PRODUCT_URL_WITH_USER_TENANT_TEMPLATE_PLACEHOLDER
                 = "product-url-with-user-tenant";
+        public static final String ORGANIZATION_NAME_PLACEHOLDER = "organization-name";
 
         public static final String ENABLE_ORGANIZATION_LEVEL_EMAIL_BRANDING = "EnableOrganizationLevelEmailBranding";
         public static final String ORGANIZATION_LEVEL_EMAIL_BRANDING_FALLBACKS_ELEM

--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/internal/NotificationHandlerDataHolder.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/internal/NotificationHandlerDataHolder.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.identity.event.handler.notification.internal;
 import org.wso2.carbon.event.publisher.core.EventPublisherService;
 import org.wso2.carbon.event.stream.core.EventStreamService;
 import org.wso2.carbon.identity.governance.service.notification.NotificationTemplateManager;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.registry.core.service.RegistryService;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.utils.ConfigurationContextService;
@@ -35,6 +36,7 @@ public class NotificationHandlerDataHolder {
     private EventPublisherService eventPublisherService = null;
     private EmailTemplateManager emailTemplateManager = null;
     private NotificationTemplateManager notificationTemplateManager = null;
+    private OrganizationManager organizationManager;
 
     private NotificationHandlerDataHolder() {
 
@@ -103,5 +105,25 @@ public class NotificationHandlerDataHolder {
     public NotificationTemplateManager getNotificationTemplateManager() {
 
         return notificationTemplateManager;
+    }
+
+    /**
+     * Get organization manager service.
+     *
+     * @return {@link org.wso2.carbon.identity.organization.management.service.OrganizationManager} service.
+     */
+    public OrganizationManager getOrganizationManager() {
+
+        return organizationManager;
+    }
+
+    /**
+     * Set organization manager.
+     *
+     * @param organizationManager {@link org.wso2.carbon.identity.organization.management.service.OrganizationManager} service.
+     */
+    public void setOrganizationManager(OrganizationManager organizationManager) {
+
+        this.organizationManager = organizationManager;
     }
 }

--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/internal/NotificationHandlerServiceComponent.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/internal/NotificationHandlerServiceComponent.java
@@ -27,6 +27,7 @@ import org.wso2.carbon.identity.event.handler.notification.DefaultNotificationHa
 import org.wso2.carbon.identity.event.handler.notification.NotificationHandler;
 import org.wso2.carbon.identity.event.handler.notification.listener.NotificationEventTenantListener;
 import org.wso2.carbon.identity.governance.service.notification.NotificationTemplateManager;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.registry.core.service.RegistryService;
 import org.wso2.carbon.stratos.common.listeners.TenantMgtListener;
 import org.wso2.carbon.user.core.service.RealmService;
@@ -195,6 +196,21 @@ public class NotificationHandlerServiceComponent {
             log.debug("UnSetting the Notification Email Template Manager");
         }
         NotificationHandlerDataHolder.getInstance().setNotificationTemplateManager(null);
+    }
+
+    @Reference(name = "identity.organization.management.component",
+            service = OrganizationManager.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetOrganizationManager")
+    protected void setOrganizationManager(OrganizationManager organizationManager) {
+
+        NotificationHandlerDataHolder.getInstance().setOrganizationManager(organizationManager);
+    }
+
+    protected void unsetOrganizationManager(OrganizationManager organizationManager) {
+
+        NotificationHandlerDataHolder.getInstance().setOrganizationManager(null);
     }
 }
 

--- a/pom.xml
+++ b/pom.xml
@@ -248,6 +248,13 @@
                 <version>${com.fasterxml.jackson.databind.version}</version>
             </dependency>
 
+            <!-- Organization management Dependencies -->
+            <dependency>
+                <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
+                <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
+                <version>${identity.organization.management.core.version}</version>
+            </dependency>
+
             <!-- Test Dependencies -->
             <dependency>
                 <groupId>org.testng</groupId>
@@ -406,6 +413,11 @@
         <!--Carbon Identity Framework Version-->
         <carbon.identity.framework.version>5.23.17</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.14.67, 6.0.0)</carbon.identity.framework.imp.pkg.version.range>
+
+        <!-- Organization management Version -->
+        <identity.organization.management.core.version>1.0.19</identity.organization.management.core.version>
+        <org.wso2.identity.organization.mgt.core.imp.pkg.version.range>[1.0.0,2.0.0)
+        </org.wso2.identity.organization.mgt.core.imp.pkg.version.range>
 
         <!--Carbon Analytics Common Version-->
         <carbon.analytics.common.version>5.2.10</carbon.analytics.common.version>


### PR DESCRIPTION
### Proposed changes in this pull request
Set the human-readable organization name to a placeholder named "organization-name".
If the tenant has an associated organization, the tenant id will be a UUID. The UUID value should not display on emails