### PR TITLE
Add email template for account activation after ask password flow

### DIFF
--- a/features/org.wso2.carbon.email.mgt.server.feature/resources/email-admin-config.xml
+++ b/features/org.wso2.carbon.email.mgt.server.feature/resources/email-admin-config.xml
@@ -1377,6 +1377,57 @@
         </table>]]></body>
         <footer>---</footer>
     </configuration>
+    <configuration type="accountActivationSuccess" display="accountActivationSuccess" locale="en_US" emailContentType="text/html">
+        <subject>WSO2 - Account Activation Successful</subject>
+        <body><![CDATA[<table align="center" cellpadding="0" cellspacing="0" border="0" width="100%"bgcolor="#f0f0f0">
+            <tr>
+            <td style="padding: 30px 30px 20px 30px;">
+                <table cellpadding="0" cellspacing="0" border="0" width="100%" bgcolor="#ffffff" style="max-width: 650px; margin: auto;">
+                <tr>
+                    <td colspan="2" align="center" style="background-color: #333; padding: 40px;">
+                        <a href="http://wso2.com/" target="_blank"><img src="http://cdn.wso2.com/wso2/newsletter/images/nl-2017/wso2-logo-transparent.png" border="0"/></a>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2" align="center" style="padding: 50px 50px 0px 50px;">
+                        <h1 style="padding-right: 0em; margin: 0; line-height: 40px; font-weight:300; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 1em;">
+                            Account Activation Successful
+                        </h1>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="text-align: left; padding: 0px 50px;" valign="top">
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 3%;">
+                            Hi {{user-name}},
+                        </p>
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 3%;">
+                            Please note that your account activation is successfully completed.
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="text-align: left; padding: 30px 50px 50px 50px" valign="top">
+                        <p style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #505050; text-align: left;">
+                            Thanks,<br/>WSO2 Identity Server Team
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2" align="center" style="padding: 20px 40px 40px 40px;" bgcolor="#f0f0f0">
+                        <p style="font-size: 12px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #777;">
+                            &copy;2020
+                            <a href="http://wso2.com/" target="_blank" style="color: #777; text-decoration: none">WSO2</a>
+                            <br>
+                            787 Castro Street, Mountain View, CA 94041.
+                        </p>
+                    </td>
+                </tr>
+                </table>
+            </td>
+            </tr>
+        </table>]]></body>
+        <footer>---</footer>
+    </configuration>
     <configuration type="initiateRecovery" display="initiateRecovery" locale="en_US" emailContentType="text/html">
         <subject>WSO2 - Password Reset Initiated</subject>
         <body><![CDATA[<table align="center" cellpadding="0" cellspacing="0" border="0" width="100%"bgcolor="#f0f0f0">


### PR DESCRIPTION
### Purpose

It is required to send an account activation mail after the user completes the ask password flow. Therefore adding this mail template for that

![Screenshot from 2022-11-22 17-32-23](https://user-images.githubusercontent.com/25496816/203309187-c0c0d484-4935-4088-9c6d-8505c57b7959.png)


Resolves: https://github.com/wso2/product-is/issues/15167
Related PR:https://github.com/wso2-extensions/identity-governance/pull/640