### PR TITLE
Use secureDocumentBuilderFactory instead of the DocumentBuilderFactory

### DIFF
--- a/components/notification-sender-config/org.wso2.carbon.identity.notification.sender.tenant.config/src/main/java/org/wso2/carbon/identity/notification/sender/tenant/config/utils/NotificationSenderUtils.java
+++ b/components/notification-sender-config/org.wso2.carbon.identity.notification.sender.tenant.config/src/main/java/org/wso2/carbon/identity/notification/sender/tenant/config/utils/NotificationSenderUtils.java
@@ -22,6 +22,7 @@ import org.apache.commons.lang.StringUtils;
 import org.w3c.dom.Attr;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.notification.sender.tenant.config.dto.EmailSenderDTO;
 import org.wso2.carbon.identity.notification.sender.tenant.config.dto.SMSSenderDTO;
 import org.wso2.carbon.identity.notification.sender.tenant.config.internal.NotificationSenderTenantConfigDataHolder;
@@ -106,7 +107,7 @@ public class NotificationSenderUtils {
             throws ParserConfigurationException, TransformerException {
 
         Map<String, String> properties = emailSender.getProperties();
-        DocumentBuilderFactory documentFactory = DocumentBuilderFactory.newInstance();
+        DocumentBuilderFactory documentFactory = IdentityUtil.getSecuredDocumentBuilderFactory();
         DocumentBuilder documentBuilder = documentFactory.newDocumentBuilder();
         Document document = documentBuilder.newDocument();
         // Root element (eventPublisher).
@@ -142,7 +143,7 @@ public class NotificationSenderUtils {
             throws ParserConfigurationException, TransformerException {
 
         Map<String, String> properties = smsSender.getProperties();
-        DocumentBuilderFactory documentFactory = DocumentBuilderFactory.newInstance();
+        DocumentBuilderFactory documentFactory = IdentityUtil.getSecuredDocumentBuilderFactory();
         DocumentBuilder documentBuilder = documentFactory.newDocumentBuilder();
         Document document = documentBuilder.newDocument();
         // Root element (eventPublisher).


### PR DESCRIPTION
### Purpose

As per section 2.4 in [WSO2 Secure Engineering Guidelines](https://wso2.com/technical-reports/wso2-secure-engineering-guidelines/), it requires to use the secure document builder.


`DocumentBuilderFactory documentFactory = IdentityUtil.getSecuredDocumentBuilderFactory();`

The commit contains the above change.