### PR TITLE
Modify the magic link email notification

### DIFF
--- a/features/org.wso2.carbon.email.mgt.server.feature/resources/email-admin-config.xml
+++ b/features/org.wso2.carbon.email.mgt.server.feature/resources/email-admin-config.xml
@@ -2316,7 +2316,7 @@
                                     </p>
                                     <p
                                         style="font-size: 18px; margin: 0; line-height: 24px; font-family: 'Nunito Sans', Arial, Verdana, Helvetica, sans-serif; color: #666; text-align: left; padding-bottom: 3%;">
-                                        Please click the button to sign in to {{application-name}}. Be sure to use the same browser as your app.
+                                        Please click the button to sign in to {{application-name}}.
                                     </p>
                                 </td>
                             </tr>


### PR DESCRIPTION
### Proposed changes in this pull request
- With https://github.com/wso2/carbon-identity-framework/pull/4587 feature, users no longer need to use the same browser to log in with MagicLink authenticator. Therefore updated the email notification message according to that modification. 


