### PR TITLE
Add configuration support for the default notification locale

### DIFF
--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/DefaultNotificationHandler.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/DefaultNotificationHandler.java
@@ -139,7 +139,7 @@ public class DefaultNotificationHandler extends AbstractEventHandler {
             }
 
             // Resolve notification template locale according to the notification channel.
-            String locale = NotificationConstants.EmailNotification.LOCALE_DEFAULT;
+            String locale = NotificationUtil.getNotificationLocale();
             if (NotificationChannels.SMS_CHANNEL.getChannelType().equals(notificationChannel) && userClaims
                     .containsKey(NotificationConstants.SMSNotification.DEFAULT_SMS_NOTIFICATION_LOCALE)) {
                 locale = userClaims.get(NotificationConstants.SMSNotification.DEFAULT_SMS_NOTIFICATION_LOCALE);

--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/NotificationConstants.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/NotificationConstants.java
@@ -30,6 +30,7 @@ public class NotificationConstants {
     public static final String ARBITRARY_SEND_TO = "send-to";
     public static final String ARBITRARY_BODY = "body";
     public static final String DEFAULT_NOTIFICATION_LOCALE = "en_US";
+    public static final String NOTIFICATION_DEFAULT_LOCALE = "Notification.DefaultLocale";
 
     public static class EmailNotification {
         public static final String EMAIL_TEMPLATE_PATH = "identity/Email/";

--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/util/NotificationUtil.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/util/NotificationUtil.java
@@ -523,7 +523,7 @@ public class NotificationUtil {
             userClaims = NotificationUtil.getUserClaimValues(username, userStoreDomainName, tenantDomain);
         }
 
-        String locale = NotificationConstants.EmailNotification.LOCALE_DEFAULT;
+        String locale = getNotificationLocale();
         if (userClaims.containsKey(NotificationConstants.EmailNotification.CLAIM_URI_LOCALE)) {
             locale = userClaims.get(NotificationConstants.EmailNotification.CLAIM_URI_LOCALE);
         }
@@ -600,6 +600,18 @@ public class NotificationUtil {
             throw new IdentityEventException(e.getMessage(), e);
         }
         return organizationName;
+    }
+
+    /**
+     * Get the notification locale.
+     *
+     * @return Locale
+     */
+    public static String getNotificationLocale() {
+
+        return StringUtils.isNotBlank(IdentityUtil.getProperty(NotificationConstants.NOTIFICATION_DEFAULT_LOCALE))
+                ? IdentityUtil.getProperty(NotificationConstants.NOTIFICATION_DEFAULT_LOCALE)
+                : NotificationConstants.EmailNotification.LOCALE_DEFAULT;
     }
 }
 


### PR DESCRIPTION
### Proposed changes in this pull request

- This PR will introduce a configuration support set the default notification locale in email templates and SMS. The following config should be added to the deployment.toml to set default locale.

```
[identity_mgt.notification]
default_locale =  "<locale>"
````

if the configuration is defined in the deployment.toml file will set it as the locale for both SMS and email flow otherwise it will assign the default value as (en_US) .

Related issue: https://github.com/wso2/product-is/issues/15940

### When should this PR be merged

[Please describe any preconditions that need to be addressed before we
can merge this pull request.]


### Follow up actions

[List any possible follow-up actions here; for instance, testing data
migrations, software that we need to install on staging and production
environments.]

-


### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description.
- [ ] **Is the PR labeled correctly?**

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled.

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests.
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/).

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components.
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?**
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes should be documented.
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented.
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki.
