### PR TITLE
Enable SMS OTP configuration retrieval from primary org

### DIFF
--- a/components/notification-sender-config/org.wso2.carbon.identity.notification.sender.tenant.config/pom.xml
+++ b/components/notification-sender-config/org.wso2.carbon.identity.notification.sender.tenant.config/pom.xml
@@ -46,6 +46,22 @@
             <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.configuration.mgt.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.application.mgt</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.core</artifactId>
+        </dependency>
         <!--Test dependencies-->
         <dependency>
             <groupId>org.testng</groupId>
@@ -114,15 +130,28 @@
 
                             org.wso2.carbon.idp.mgt.model; version="${carbon.identity.framework.imp.pkg.version.range}",
 
-                            org.wso2.carbon.identity.configuration.mgt.core; version="${carbon.identity.framework.imp.pkg.version.range}",
-                            org.wso2.carbon.identity.configuration.mgt.core.exception; version="${carbon.identity.framework.imp.pkg.version.range}",
-                            org.wso2.carbon.identity.configuration.mgt.core.model; version="${carbon.identity.framework.imp.pkg.version.range}",
-                            org.wso2.carbon.identity.configuration.mgt.core.constant; version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.configuration.mgt.core;
+                            version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.configuration.mgt.core.exception;
+                            version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.configuration.mgt.core.model;
+                            version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.configuration.mgt.core.constant;
+                            version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.core.util;
+                            version="${carbon.identity.framework.imp.pkg.version.range}",
 
                             org.wso2.carbon.identity.tenant.resource.manager.core; version="${identity.governance.imp.pkg.version.range}",
                             org.wso2.carbon.identity.tenant.resource.manager.exception; version="${identity.governance.imp.pkg.version.range}",
                             org.wso2.carbon.identity.tenant.resource.manager.util; version="${identity.governance.imp.pkg.version.range}",
-                            org.wso2.carbon.utils; version="${carbon.kernel.imp.pkg.version.range}"
+                            org.wso2.carbon.utils; version="${carbon.kernel.imp.pkg.version.range}",
+
+                            org.wso2.carbon.identity.organization.management.service;
+                            version="${org.wso2.identity.organization.mgt.core.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.organization.management.service.util;
+                            version="${org.wso2.identity.organization.mgt.core.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.organization.management.service.exception;
+                            version="${org.wso2.identity.organization.mgt.core.imp.pkg.version.range}"
                         </Import-Package>
                     </instructions>
                 </configuration>

--- a/components/notification-sender-config/org.wso2.carbon.identity.notification.sender.tenant.config/src/main/java/org/wso2/carbon/identity/notification/sender/tenant/config/NotificationSenderManagementService.java
+++ b/components/notification-sender-config/org.wso2.carbon.identity.notification.sender.tenant.config/src/main/java/org/wso2/carbon/identity/notification/sender/tenant/config/NotificationSenderManagementService.java
@@ -74,6 +74,23 @@ public interface NotificationSenderManagementService {
     SMSSenderDTO getSMSSender(String senderName) throws NotificationSenderManagementException;
 
     /**
+     * Retrieve the sms sender details by name for the current organization with an option to exclude inherited
+     * tenant settings.
+     * When the 'inheritTenantSettings' flag is set to true, the method includes configurations from the parent tenant.
+     * When set to false, it retrieves only the configurations explicitly set for the current tenant.
+     *
+     * @param inheritTenantSettings Whether to retrieve inherit tenant settings.
+     * @param senderName SMS sender's name.
+     * @return SMS sender.
+     * @throws NotificationSenderManagementException    Notification sender management exception.
+     */
+    default SMSSenderDTO getSMSSender(String senderName, boolean inheritTenantSettings)
+            throws NotificationSenderManagementException {
+
+        return getSMSSender(senderName);
+    }
+
+    /**
      * Retrieve all email senders of the tenant.
      *
      * @return Email senders of the tenant.
@@ -88,6 +105,21 @@ public interface NotificationSenderManagementService {
      * @throws NotificationSenderManagementException    Notification sender management exception.
      */
     List<SMSSenderDTO> getSMSSenders() throws NotificationSenderManagementException;
+
+    /**
+     * Retrieves all SMS senders configured for the current tenant with an option to exclude inherited tenant settings.
+     * When the 'inheritTenantSettings' flag is set to true, the method includes configurations from the parent tenant.
+     * When set to false, it retrieves only the configurations explicitly set for the current tenant.
+     *
+     * @param inheritTenantSettings Whether to retrieve inherit tenant settings.
+     * @return SMS senders of the tenant.
+     * @throws NotificationSenderManagementException    Notification sender management exception.
+     */
+    default List<SMSSenderDTO> getSMSSenders(boolean inheritTenantSettings)
+            throws NotificationSenderManagementException {
+
+        return getSMSSenders();
+    }
 
     /**
      * Update email sender details.

--- a/components/notification-sender-config/org.wso2.carbon.identity.notification.sender.tenant.config/src/main/java/org/wso2/carbon/identity/notification/sender/tenant/config/NotificationSenderManagementServiceImpl.java
+++ b/components/notification-sender-config/org.wso2.carbon.identity.notification.sender.tenant.config/src/main/java/org/wso2/carbon/identity/notification/sender/tenant/config/NotificationSenderManagementServiceImpl.java
@@ -312,6 +312,7 @@ public class NotificationSenderManagementServiceImpl implements NotificationSend
     }
 
     private List<SMSSenderDTO> extractSMSSenders(Resources publisherResources) {
+
         return publisherResources.getResources().stream()
                 .filter(resource -> resource.getAttributes().stream()
                         .anyMatch(attribute -> PUBLISHER_TYPE_PROPERTY.equals(attribute.getKey()) &&

--- a/components/notification-sender-config/org.wso2.carbon.identity.notification.sender.tenant.config/src/main/java/org/wso2/carbon/identity/notification/sender/tenant/config/NotificationSenderManagementServiceImpl.java
+++ b/components/notification-sender-config/org.wso2.carbon.identity.notification.sender.tenant.config/src/main/java/org/wso2/carbon/identity/notification/sender/tenant/config/NotificationSenderManagementServiceImpl.java
@@ -306,7 +306,7 @@ public class NotificationSenderManagementServiceImpl implements NotificationSend
                 publisherResources.getResources().isEmpty()) {
             publisherResources = NotificationSenderTenantConfigDataHolder.getInstance()
                     .getConfigurationManager()
-                    .getResourcesByType(getPrimaryTenantId(tenantDomain), PUBLISHER_RESOURCE_TYPE);
+                    .getResourcesByType(getPrimaryTenantId(), PUBLISHER_RESOURCE_TYPE);
         }
         return publisherResources;
     }
@@ -736,7 +736,6 @@ public class NotificationSenderManagementServiceImpl implements NotificationSend
     /**
      * Get the primary tenant id of the given tenant domain.
      *
-     * @param tenantDomain Tenant domain.
      * @return Primary tenant id.
      * @throws OrganizationManagementException If an error occurred while getting the primary tenant id.
      */

--- a/components/notification-sender-config/org.wso2.carbon.identity.notification.sender.tenant.config/src/main/java/org/wso2/carbon/identity/notification/sender/tenant/config/internal/NotificationSenderTenantConfigDataHolder.java
+++ b/components/notification-sender-config/org.wso2.carbon.identity.notification.sender.tenant.config/src/main/java/org/wso2/carbon/identity/notification/sender/tenant/config/internal/NotificationSenderTenantConfigDataHolder.java
@@ -24,6 +24,7 @@ import org.wso2.carbon.event.publisher.core.EventPublisherService;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
 import org.wso2.carbon.identity.notification.sender.tenant.config.handlers.ChannelConfigurationHandler;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.identity.tenant.resource.manager.core.ResourceManager;
 
 import java.util.HashMap;
@@ -43,6 +44,7 @@ public class NotificationSenderTenantConfigDataHolder {
     private SMSProviderPayloadTemplateManager smsProviderPayloadTemplateManager = null;
     Map<String, ChannelConfigurationHandler> configurationHandlerMap = new HashMap<>();
     private ApplicationManagementService applicationManagementService = null;
+    private OrganizationManager organizationManager = null;
 
     private NotificationSenderTenantConfigDataHolder() {
     }
@@ -125,5 +127,15 @@ public class NotificationSenderTenantConfigDataHolder {
     public ApplicationManagementService getApplicationManagementService() {
 
         return applicationManagementService;
+    }
+
+    public void setOrganizationManager(OrganizationManager organizationManager) {
+
+        this.organizationManager = organizationManager;
+    }
+
+    public OrganizationManager getOrganizationManager() {
+
+        return organizationManager;
     }
 }

--- a/components/notification-sender-config/org.wso2.carbon.identity.notification.sender.tenant.config/src/main/java/org/wso2/carbon/identity/notification/sender/tenant/config/internal/NotificationSenderTenantConfigServiceDS.java
+++ b/components/notification-sender-config/org.wso2.carbon.identity.notification.sender.tenant.config/src/main/java/org/wso2/carbon/identity/notification/sender/tenant/config/internal/NotificationSenderTenantConfigServiceDS.java
@@ -35,6 +35,7 @@ import org.wso2.carbon.identity.notification.sender.tenant.config.NotificationSe
 import org.wso2.carbon.identity.notification.sender.tenant.config.NotificationSenderManagementServiceImpl;
 import org.wso2.carbon.identity.notification.sender.tenant.config.handlers.ChannelConfigurationHandler;
 import org.wso2.carbon.identity.notification.sender.tenant.config.handlers.DefaultChannelConfigurationHandler;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.identity.tenant.resource.manager.core.ResourceManager;
 import org.wso2.carbon.utils.ConfigurationContextService;
 
@@ -114,6 +115,22 @@ public class NotificationSenderTenantConfigServiceDS {
             log.debug("Un Setting theCarbonEventPublisherService Service");
         }
         NotificationSenderTenantConfigDataHolder.getInstance().setConfigurationManager(null);
+    }
+
+    @Reference(
+            name = "organization.management.service",
+            service = OrganizationManager.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetOrganizationManager")
+    protected void setOrganizationManager(OrganizationManager organizationManager) {
+
+        NotificationSenderTenantConfigDataHolder.getInstance().setOrganizationManager(organizationManager);
+    }
+
+    protected void unsetOrganizationManager(OrganizationManager organizationManager) {
+
+        NotificationSenderTenantConfigDataHolder.getInstance().setOrganizationManager(null);
     }
 
     @Reference(name = "config.context.service",

--- a/pom.xml
+++ b/pom.xml
@@ -433,7 +433,7 @@
         <carbon.commons.imp.pkg.version>[4.7.11, 5.0.0)</carbon.commons.imp.pkg.version>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.25.600</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.617</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.14.67, 7.0.0)</carbon.identity.framework.imp.pkg.version.range>
 
         <!-- Organization management Version -->

--- a/pom.xml
+++ b/pom.xml
@@ -147,6 +147,16 @@
                 <artifactId>org.wso2.carbon.identity.central.log.mgt</artifactId>
                 <version>${carbon.identity.framework.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.configuration.mgt.core</artifactId>
+                <version>${carbon.identity.framework.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.application.mgt</artifactId>
+                <version>${carbon.identity.framework.version}</version>
+            </dependency>
 
             <!--Carbon Analytics Common Dependencies-->
             <dependency>
@@ -423,11 +433,11 @@
         <carbon.commons.imp.pkg.version>[4.7.11, 5.0.0)</carbon.commons.imp.pkg.version>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.25.461</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.600</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.14.67, 7.0.0)</carbon.identity.framework.imp.pkg.version.range>
 
         <!-- Organization management Version -->
-        <identity.organization.management.core.version>1.0.19</identity.organization.management.core.version>
+        <identity.organization.management.core.version>1.0.93</identity.organization.management.core.version>
         <org.wso2.identity.organization.mgt.core.imp.pkg.version.range>[1.0.0,2.0.0)
         </org.wso2.identity.organization.mgt.core.imp.pkg.version.range>
 


### PR DESCRIPTION
### Proposed changes in this pull request
$subject
This PR updates the SMS configuration retrieval process. Now, if SMS configurations are not found in a sub-organization, they will be fetched from the primary organization for event handling. However, API calls will only access configurations specific to their own organization and not inherit from the parent.

### When should this PR be merged
Merge after
- https://github.com/wso2/carbon-identity-framework/pull/5312

### Relevant Issues
- https://github.com/wso2/product-is/issues/18247
