### PR TITLE
Introduce application specific email templates

### DIFF
--- a/components/email-mgt/org.wso2.carbon.email.mgt/pom.xml
+++ b/components/email-mgt/org.wso2.carbon.email.mgt/pom.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-~ Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+~ Copyright (c) 2016-2024, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
 ~
-~  WSO2 Inc. licenses this file to you under the Apache License,
+~  WSO2 LLC. licenses this file to you under the Apache License,
 ~  Version 2.0 (the "License"); you may not use this file except
 ~  in compliance with the License.
 ~  You may obtain a copy of the License at
@@ -33,6 +33,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.wso2.carbon</groupId>
+            <artifactId>org.wso2.carbon.core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.carbon.identity.governance</groupId>
             <artifactId>org.wso2.carbon.identity.governance</artifactId>
         </dependency>
@@ -43,10 +47,6 @@
         <dependency>
             <groupId>org.wso2.carbon</groupId>
             <artifactId>org.wso2.carbon.registry.core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.wso2.carbon</groupId>
-            <artifactId>org.wso2.carbon.core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon</groupId>

--- a/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/EmailTemplateManager.java
+++ b/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/EmailTemplateManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2016-2024, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -106,6 +106,21 @@ public interface EmailTemplateManager {
     }
 
     /**
+     * Get all email templates of a specific template type for an application, from tenant registry.
+     *
+     * @param templateDisplayName Email template type displace name.
+     * @param tenantDomain Tenant domain.
+     * @param applicationUuid Application UUID.
+     * @return A list of email templates that matches to the provided template type.
+     * @throws I18nEmailMgtException if an error occurred.
+     */
+    default List<EmailTemplate> getEmailTemplateType(
+            String templateDisplayName, String tenantDomain, String applicationUuid) throws I18nEmailMgtException {
+
+        throw new I18nEmailMgtException("Method not implemented");
+    }
+
+    /**
      * Get all available email templates in a tenant's registry.
      *
      * @param tenantDomain
@@ -148,5 +163,63 @@ public interface EmailTemplateManager {
             throws I18nEmailMgtException {
 
         throw new I18nEmailMgtException("Method not yet supported");
+    }
+
+    /**
+     * Add an application email template to tenant registry.
+     *
+     * @param emailTemplate Email template to be added.
+     * @param tenantDomain Tenant domain.
+     * @param applicationUuid Application UUID.
+     * @throws I18nEmailMgtException If an error occurred while adding the email template.
+     */
+    void addEmailTemplate(EmailTemplate emailTemplate,
+                          String tenantDomain,
+                          String applicationUuid) throws I18nEmailMgtException;
+
+    /**
+     * Delete an application email template from the tenant registry. Email template is identified with the
+     * templateTypeName, localeCode and application UUID.
+     *
+     * @param templateTypeName Email template type name.
+     * @param localeCode Locale code of the email template.
+     * @param tenantDomain Tenant domain.
+     * @param applicationUuid Application UUID.
+     * @throws I18nEmailMgtException If an error occurred while deleting the email template.
+     */
+    void deleteEmailTemplate(String templateTypeName,
+                             String localeCode,
+                             String tenantDomain,
+                             String applicationUuid) throws I18nEmailMgtException;
+
+    /**
+     * Get an email template from tenant registry with application UUID.
+     *
+     * @param templateType Email template type.
+     * @param locale Locale of the email template.
+     * @param tenantDomain Tenant domain.
+     * @param applicationUuid Application UUID.
+     * @return Email template of the application with fallback to organization template.
+     * @throws I18nEmailMgtException If an error occurred while getting the email template.
+     */
+    EmailTemplate getEmailTemplate(String templateType,
+                                   String locale,
+                                   String tenantDomain,
+                                   String applicationUuid) throws I18nEmailMgtException;
+
+    /**
+     * Check whether the given email template type exists for the application.
+     *
+     * @param templateTypeDisplayName Display name of the template type.
+     * @param locale                  Locale of the email template
+     * @param tenantDomain            Tenant Domain
+     * @param applicationUuid         Application UUID
+     * @return True if the template type exists, false otherwise.
+     * @throws I18nEmailMgtException If an error occurred while checking the existence of the email template.
+     */
+    default boolean isEmailTemplateExists(String templateTypeDisplayName, String locale,
+                                          String tenantDomain, String applicationUuid) throws I18nEmailMgtException {
+
+        throw new I18nEmailMgtException("Method not implemented");
     }
 }

--- a/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/EmailTemplateManager.java
+++ b/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/EmailTemplateManager.java
@@ -77,6 +77,29 @@ public interface EmailTemplateManager {
                              String localeCode,
                              String tenantDomain) throws I18nEmailMgtException;
 
+    /**
+     * Delete all email templates from the tenant registry. Email templates are identified with the templateTypeName and
+     * localeCode.
+     *
+     * @param templateTypeName Email template type name.
+     * @param tenantDomain Tenant domain.
+     * @throws I18nEmailMgtException If an error occurred while deleting the email templates.
+     */
+    void deleteEmailTemplates(String templateTypeName, String tenantDomain) throws I18nEmailMgtException;
+
+    /**
+     * Delete all email templates from the tenant registry. Email templates are identified with the templateTypeName,
+     * localeCode and application UUID.
+     *
+     * @param templateTypeName Email template type name.
+     * @param tenantDomain Tenant domain.
+     * @param applicationUuid Application UUID.
+     * @throws I18nEmailMgtException If an error occurred while deleting the email templates.
+     */
+    void deleteEmailTemplates(String templateTypeName,
+                              String tenantDomain,
+                              String applicationUuid) throws I18nEmailMgtException;
+
 
     /**
      * Get an email template from tenant registry.

--- a/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/EmailTemplateManagerImpl.java
+++ b/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/EmailTemplateManagerImpl.java
@@ -819,6 +819,12 @@ public class EmailTemplateManagerImpl implements EmailTemplateManager, Notificat
         }
     }
 
+    /**
+     * Build application template path from application UUID or return empty string if application UUID is null.
+     *
+     * @param applicationUuid Application UUID.
+     * @return Application template path.
+     */
     private String getApplicationPath(String applicationUuid) {
 
         if (StringUtils.isNotBlank(applicationUuid)) {
@@ -949,6 +955,7 @@ public class EmailTemplateManagerImpl implements EmailTemplateManager, Notificat
         }
         for (String template : templateType.getChildren()) {
             Resource templateResource = resourceMgtService.getIdentityResource(template, tenantDomain);
+            // Exclude the app templates for organization template requests.
             if (templateResource != null && (templateTypeRegistryPath.contains(APP_TEMPLATE_PATH)
                     || !templateResource.getPath().contains(APP_TEMPLATE_PATH))) {
                 try {
@@ -1050,21 +1057,21 @@ public class EmailTemplateManagerImpl implements EmailTemplateManager, Notificat
     /**
      * Build the template type root directory path.
      *
-     * @param type                Template type
-     * @param notificationChannel Notification channel (SMS or EMAIL)
+     * @param templateType          Template type
+     * @param notificationChannel   Notification channel (SMS or EMAIL)
      * @return Root directory path
      */
-    private String buildTemplateRootDirectoryPath(String type, String notificationChannel) {
+    private String buildTemplateRootDirectoryPath(String templateType, String notificationChannel) {
 
-        return buildTemplateRootDirectoryPath(type, notificationChannel, null);
+        return buildTemplateRootDirectoryPath(templateType, notificationChannel, null);
     }
 
-    private String buildTemplateRootDirectoryPath(String type, String notificationChannel, String applicationUuid) {
+    private String buildTemplateRootDirectoryPath(String templateType, String notificationChannel, String applicationUuid) {
 
         if (NotificationChannels.SMS_CHANNEL.getChannelType().equals(notificationChannel)) {
-            return SMS_TEMPLATE_PATH + PATH_SEPARATOR + type;
+            return SMS_TEMPLATE_PATH + PATH_SEPARATOR + templateType;
         }
-        return EMAIL_TEMPLATE_PATH + PATH_SEPARATOR + type + getApplicationPath(applicationUuid);
+        return EMAIL_TEMPLATE_PATH + PATH_SEPARATOR + templateType + getApplicationPath(applicationUuid);
     }
 
     /**

--- a/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/constants/I18nMgtConstants.java
+++ b/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/constants/I18nMgtConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2016-2024, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except
@@ -31,6 +31,7 @@ public class I18nMgtConstants {
     private I18nMgtConstants() {}
 
     public static final String EMAIL_TEMPLATE_PATH = "/identity/email";
+    public static final String APP_TEMPLATE_PATH = "/apps";
     public static final String SMS_TEMPLATE_PATH = "/identity/sms";
     public static final String EMAIL_CONF_DIRECTORY = "email";
     public static final String SMS_CONF_DIRECTORY = "sms";

--- a/components/email-mgt/org.wso2.carbon.email.mgt/src/test/java/org/wso2/carbon/email/mgt/ApplicationEmailTemplateTest.java
+++ b/components/email-mgt/org.wso2.carbon.email.mgt/src/test/java/org/wso2/carbon/email/mgt/ApplicationEmailTemplateTest.java
@@ -1,0 +1,493 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.carbon.email.mgt;
+
+import static org.mockito.MockitoAnnotations.initMocks;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+
+import org.apache.commons.lang.StringUtils;
+import org.mockito.Matchers;
+import org.mockito.Mock;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.testng.PowerMockTestCase;
+import org.testng.IObjectFactory;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.ObjectFactory;
+import org.testng.annotations.Test;
+
+import org.wso2.carbon.email.mgt.constants.I18nMgtConstants;
+import org.wso2.carbon.email.mgt.internal.I18nMgtDataHolder;
+import org.wso2.carbon.email.mgt.util.I18nEmailUtil;
+import org.wso2.carbon.identity.base.IdentityRuntimeException;
+import org.wso2.carbon.identity.base.IdentityValidationUtil;
+import org.wso2.carbon.identity.core.persistence.registry.RegistryResourceMgtService;
+import org.wso2.carbon.identity.governance.IdentityMgtConstants;
+import org.wso2.carbon.identity.governance.exceptions.notiification.NotificationTemplateManagerException;
+import org.wso2.carbon.identity.governance.model.NotificationTemplate;
+import org.wso2.carbon.identity.governance.service.notification.NotificationChannels;
+import org.wso2.carbon.registry.core.Resource;
+import org.wso2.carbon.utils.CarbonUtils;
+
+/**
+ * Class that contains the test cases for the implementation of Email Template Manager.
+ */
+@PrepareForTest({ IdentityValidationUtil.class, I18nMgtDataHolder.class, CarbonUtils.class})
+public class ApplicationEmailTemplateTest extends PowerMockTestCase {
+
+    private EmailTemplateManagerImpl emailTemplateManager;
+
+    @Mock
+    RegistryResourceMgtService resourceMgtService;
+
+    @Mock
+    I18nMgtDataHolder i18nMgtDataHolder;
+
+    @Mock
+    Resource resource;
+
+    @ObjectFactory
+    public IObjectFactory getObjectFactory() {
+
+        return new org.powermock.modules.testng.PowerMockObjectFactory();
+    }
+
+    private String tenantDomain = "carbon.super";
+
+    @BeforeMethod
+    public void setUp() {
+
+        initMocks(this);
+        mockStatic(I18nMgtDataHolder.class);
+        i18nMgtDataHolder = PowerMockito.mock(I18nMgtDataHolder.class);
+        when(I18nMgtDataHolder.getInstance()).thenReturn(i18nMgtDataHolder);
+
+        // Mock RegistryResourceMgtService.
+        when(i18nMgtDataHolder.getRegistryResourceMgtService()).thenReturn(resourceMgtService);
+        emailTemplateManager = new EmailTemplateManagerImpl();
+    }
+
+    /**
+     * Contains the test scenarios for getting notification template using the notification channel.
+     *
+     * @param notificationChannel Notification channel
+     * @param displayName         Display name
+     * @param type                Type
+     * @param locale              Locale
+     * @param contentType         Content type
+     * @param content             Template content
+     * @throws Exception Error testing getNotificationTemplate implementation.
+     */
+    @Test(dataProvider = "notificationTemplateDataProvider")
+    public void testGetNotificationTemplate(String notificationChannel, String displayName, String type, String locale,
+            String contentType, byte[] content, String applicationUuid) throws Exception {
+
+        mockRegistryResource(notificationChannel, displayName, type, locale, contentType, content);
+        mockIsValidTemplate(true, true);
+        NotificationTemplate notificationTemplate = emailTemplateManager
+                .getNotificationTemplate(notificationChannel, type, locale, tenantDomain, applicationUuid);
+        assertNotNull(notificationTemplate);
+        assertNotNull(notificationTemplate.getBody(), "Template should have a notification body");
+        assertEquals(notificationTemplate.getNotificationChannel(), notificationChannel);
+
+        // Validate not having subject or footer in SMS notification template.
+        if (NotificationChannels.SMS_CHANNEL.getChannelType().equals(notificationChannel)) {
+            assertNull(notificationTemplate.getFooter(), "SMS notification template cannot have a footer");
+            assertNull(notificationTemplate.getSubject(), "SMS notification template cannot have a subject");
+        } else {
+            assertNotNull(notificationTemplate.getFooter(), "EMAIL notification template must have a footer");
+            assertNotNull(notificationTemplate.getSubject(),
+                    "EMAIL notification template must have a subject");
+        }
+    }
+
+    /**
+     * Contains the error scenarios for resolving notification template.
+     *
+     * @param notificationChannel Notification channel
+     * @param displayName         Display name
+     * @param type                Type
+     * @param locale              Locale
+     * @param content             Template content
+     * @param isValidTemplate     Is valid template
+     * @param isValidLocale       Is valid locale
+     * @param errorMsg            Error message
+     * @param expectedErrorCode   Expected error code
+     * @param contentType         Content type
+     * @throws Exception Error testing getNotificationTemplate implementation.
+     */
+    @Test(dataProvider = "invalidNotificationTemplateDataProvider")
+    public void testGetNotificationTemplateErrors(String notificationChannel, String displayName, String type,
+            String locale, String contentType, boolean isValidTemplate, boolean isValidLocale, String errorMsg,
+            String expectedErrorCode, byte[] content, String applicationUuid) throws Exception {
+
+        mockIsValidTemplate(isValidTemplate, isValidLocale);
+        try {
+            mockRegistryResource(notificationChannel, displayName, type, locale, contentType, content);
+            NotificationTemplate notificationTemplate = emailTemplateManager
+                    .getNotificationTemplate(notificationChannel, type, locale, tenantDomain, applicationUuid);
+            assertNull(notificationTemplate, "Cannot return a notificationTemplate");
+        } catch (NotificationTemplateManagerException e) {
+            String errorCode = e.getErrorCode();
+            assertNotNull(errorCode, "Error code cannot be empty");
+            if (StringUtils.isEmpty(errorMsg)) {
+                errorMsg = e.getMessage();
+            }
+            assertEquals(errorCode, expectedErrorCode, errorMsg);
+        }
+    }
+
+    /**
+     * Test error scenarios of adding a notification template type.
+     *
+     * @param templateName Notification template name
+     * @param channel      Notification channel
+     * @param domain       Tenant domain
+     * @param errorCode    Expected error code (NOTE: Without the scenario code)
+     * @param errorMessage Error message
+     * @param scenarioCode Error scenario
+     */
+    @Test(dataProvider = "addNotificationTemplateTypeProvider")
+    public void TestAddNotificationTemplateType(String templateName, String channel, String domain, String errorCode,
+                                                String errorMessage, int scenarioCode, String applicationUuid) {
+
+        try {
+            if (scenarioCode == 2) {
+                when(resourceMgtService.isResourceExists(Matchers.anyString(), Matchers.anyString())).thenReturn(true);
+            }
+            if (scenarioCode == 3) {
+                when(resourceMgtService.isResourceExists(Matchers.anyString(), Matchers.anyString()))
+                        .thenThrow(new IdentityRuntimeException("Test Error"));
+            }
+            emailTemplateManager
+                    .addNotificationTemplateType(templateName, channel, domain, applicationUuid);
+        } catch (NotificationTemplateManagerException e) {
+            String expectedCode =
+                    I18nEmailUtil.prependOperationScenarioToErrorCode(errorCode,
+                            I18nMgtConstants.ErrorScenarios.EMAIL_TEMPLATE_MANAGER);
+            assertEquals(e.getErrorCode(), expectedCode, errorMessage);
+        }
+    }
+
+    /**
+     * Test the error scenarios of AddNotificationTemplate method.
+     *
+     * @param tenantDomain    Tenant domain
+     * @param errorCode       Error code
+     * @param errorMessage    Error message
+     * @param templateContent Contents to build notification template
+     * @throws Exception Error in the test scenario
+     */
+    @Test(dataProvider = "addNotificationTemplateProvider")
+    public void testAddNotificationTemplate(String tenantDomain, String errorCode,
+                                            String errorMessage, String[] templateContent, String applicationUuid)
+            throws Exception {
+
+        NotificationTemplate notificationTemplate;
+        if (templateContent == null) {
+            notificationTemplate = null;
+        } else {
+            notificationTemplate = buildSampleNotificationTemplate(templateContent);
+        }
+        try {
+            when(resourceMgtService.isResourceExists(Matchers.anyString(), Matchers.anyString()))
+                    .thenThrow(new IdentityRuntimeException("Test Error"));
+            emailTemplateManager.addNotificationTemplate(notificationTemplate, tenantDomain, applicationUuid);
+            throw new Exception("Exception should be thrown for above testing scenarios");
+        } catch (NotificationTemplateManagerException e) {
+            if (StringUtils.isBlank(e.getErrorCode())) {
+                throw new Exception("Error code cannot be NULL", e);
+            }
+            String expectedCode = I18nEmailUtil.prependOperationScenarioToErrorCode(errorCode,
+                    I18nMgtConstants.ErrorScenarios.EMAIL_TEMPLATE_MANAGER);
+            assertEquals(e.getErrorCode(), expectedCode, errorMessage);
+        }
+    }
+
+    /**
+     * Contains notification templates and error scenarios for addNotificationTemplate API.
+     *
+     * @return Object[][]
+     */
+    @DataProvider(name = "addNotificationTemplateProvider")
+    private Object[][] addNotificationTemplateProvider() {
+
+        String tenantDomain = "test domain";
+        String applicationUuid = "test-uuid";
+        String displayName = "Test Value";
+        String testNotificationChannel = "Test Value";
+        String type = "Test Value";
+        String contentType = "Test Value";
+        String locale = "Test Value";
+        String body = "Test Value";
+        String subject = "Test Value";
+        String footer = "Test Value";
+        String smsChannel = NotificationChannels.SMS_CHANNEL.getChannelType();
+        String emailChannel = NotificationChannels.EMAIL_CHANNEL.getChannelType();
+
+        String errorCode1 = I18nMgtConstants.ErrorMessages.ERROR_CODE_NULL_TEMPLATE_OBJECT.getCode();
+        String message1 = "Empty NotificationTemplate object :";
+
+        String errorCode2 = I18nMgtConstants.ErrorMessages.ERROR_CODE_EMPTY_TEMPLATE_NAME.getCode();
+        String message2 = "Empty template name in the notification template object : ";
+        String[] templateContent2 =
+                {StringUtils.EMPTY, testNotificationChannel, type, contentType, locale, body, subject, footer};
+
+        String errorCode3 = I18nMgtConstants.ErrorMessages.ERROR_CODE_EMPTY_LOCALE.getCode();
+        String message3 = "Empty locale in the notification template object : ";
+        String[] templateContent3 =
+                {displayName, testNotificationChannel, type, contentType, StringUtils.EMPTY, body, subject, footer};
+
+        String errorCode4 = I18nMgtConstants.ErrorMessages.ERROR_CODE_INVALID_SMS_TEMPLATE.getCode();
+        String message4 = "Invalid SMS template : ";
+        String[] templateContent4 =
+                {displayName, smsChannel, type, contentType, locale, StringUtils.EMPTY, subject, footer};
+
+        String errorCode5 = I18nMgtConstants.ErrorMessages.ERROR_CODE_EMPTY_TEMPLATE_CHANNEL.getCode();
+        String message5 = "Empty notification channel in the notification template object : ";
+        String[] templateContent5 = {displayName, StringUtils.EMPTY, type, contentType, locale, body, subject, footer};
+
+        String errorCode6 = I18nMgtConstants.ErrorMessages.ERROR_CODE_INVALID_SMS_TEMPLATE_CONTENT.getCode();
+        String message6 = "Invalid content in the SMS template : ";
+        String[] templateContent6 = {displayName, smsChannel, type, contentType, locale, body, subject, footer};
+
+        String errorCode7 = I18nMgtConstants.ErrorMessages.ERROR_CODE_INVALID_EMAIL_TEMPLATE.getCode();
+        String message7 = "Invalid EMAIL template : ";
+        String[] templateContent7 =
+                {displayName, emailChannel, type, contentType, locale, body, StringUtils.EMPTY, footer};
+
+        String errorCode8 = I18nMgtConstants.ErrorMessages.ERROR_CODE_ERROR_ERROR_ADDING_TEMPLATE.getCode();
+        String message8 = "Invalid EMAIL template : ";
+        String[] templateContent8 =
+                {displayName, emailChannel, type, contentType, locale, body, subject, footer};
+
+        return new Object[][]{
+                {tenantDomain, errorCode1, message1, null, applicationUuid},
+                {tenantDomain, errorCode2, message2, templateContent2, applicationUuid},
+                {tenantDomain, errorCode3, message3, templateContent3, applicationUuid},
+                {tenantDomain, errorCode4, message4, templateContent4, applicationUuid},
+                {tenantDomain, errorCode5, message5, templateContent5, applicationUuid},
+                {tenantDomain, errorCode6, message6, templateContent6, applicationUuid},
+                {tenantDomain, errorCode7, message7, templateContent7, applicationUuid},
+                {tenantDomain, errorCode8, message8, templateContent8, applicationUuid}
+        };
+    }
+
+    /**
+     * Contains the details of error codes and error scenarios.
+     *
+     * @return Object[][]
+     */
+    @DataProvider(name = "addNotificationTemplateTypeProvider")
+    private Object[][] addNotificationTemplateTypeProvider() {
+
+        String testTemplateName = "Test template";
+        String testChannel = "Test Channel";
+        String testDomain = "Test Domain";
+        String applicationUuid = "test-uuid";
+
+        int testScenario1 = 1;
+        String expectedErrorCode1 = I18nMgtConstants.ErrorMessages.ERROR_CODE_EMPTY_TEMPLATE_NAME.getCode();
+        String errorMessage1 = "TEST EMPTY notification template template name : ";
+
+        int testScenario2 = 2;
+        String expectedErrorCode2 = I18nMgtConstants.ErrorMessages.ERROR_CODE_DUPLICATE_TEMPLATE_TYPE.getCode();
+        String errorMessage2 = "TEST already existing resource : ";
+
+        int testScenario3 = 3;
+        String expectedErrorCode3 = I18nMgtConstants.ErrorMessages.ERROR_CODE_ERROR_ADDING_TEMPLATE.getCode();
+        String errorMessage3 = "TEST runtime exception while looking for the resource : ";
+
+        return new Object[][]{
+                {StringUtils.EMPTY, testChannel, testDomain, expectedErrorCode1, errorMessage1, testScenario1,
+                        applicationUuid},
+                {testTemplateName, testChannel, testDomain, expectedErrorCode2, errorMessage2, testScenario2,
+                        applicationUuid},
+                {testTemplateName, testChannel, testDomain, expectedErrorCode3, errorMessage3, testScenario3,
+                        applicationUuid}
+        };
+    }
+
+    /**
+     * Contains the template details and the expected outcome for the scenarios.
+     *
+     * @return Object[][]
+     * @throws Exception Error converting to a byte []
+     */
+    @DataProvider(name = "notificationTemplateDataProvider")
+    private Object[][] notificationTemplateDataProvider() throws Exception {
+
+        String locale = "en_US";
+        String notificationTemplateType = "accountconfirmation";
+        String charsetName = "UTF-8";
+        String contentType = "html/plain";
+        String applicationUuid1 = "test-uuid1";
+        String applicationUuid2 = "test-uuid2";
+
+        // Template 1: SMS.
+        String notificationChannel1 = NotificationChannels.SMS_CHANNEL.getChannelType();
+        String templateContentType1 = StringUtils.EMPTY;
+        byte[] templateContent1 = "[\"body\"]".getBytes(charsetName);
+
+        // Template 2: EMAIL.
+        String notificationChannel2 = NotificationChannels.EMAIL_CHANNEL.getChannelType();
+        byte[] templateContent2 = "[\"subject\",\"body\",\"footer\"]".getBytes(charsetName);
+
+        return new Object[][] {
+                { notificationChannel1, notificationTemplateType, notificationTemplateType, locale,
+                        templateContentType1, templateContent1, applicationUuid1 },
+                { notificationChannel2, notificationTemplateType, notificationTemplateType, locale,
+                        contentType, templateContent2, applicationUuid2 }
+        };
+    }
+
+    /**
+     * Contains data for invalid requests.
+     *
+     * @return Object[][]
+     */
+    @DataProvider(name = "invalidNotificationTemplateDataProvider")
+    private Object[][] invalidNotificationTemplateDataProvider() throws Exception{
+
+        String locale = "en_US";
+        String notificationTemplateType = "accountconfirmation";
+        String charsetName = "UTF-8";
+        String contentType = "html/plain";
+
+        // Invalid template type.
+        String errorMsg1 = "Invalid template type : ";
+        String expectedErrorCode1 = I18nEmailUtil.prependOperationScenarioToErrorCode(
+                I18nMgtConstants.ErrorMessages.ERROR_CODE_INVALID_CHARACTERS_IN_TEMPLATE_NAME.getCode(),
+                I18nMgtConstants.ErrorScenarios.EMAIL_TEMPLATE_MANAGER);
+
+        // Invalid template locale.
+        String errorMsg2 = "Invalid template locale : ";
+        String expectedErrorCode2 =
+                I18nEmailUtil.prependOperationScenarioToErrorCode(
+                        I18nMgtConstants.ErrorMessages.ERROR_CODE_INVALID_CHARACTERS_IN_LOCALE.getCode(),
+                        I18nMgtConstants.ErrorScenarios.EMAIL_TEMPLATE_MANAGER);
+
+        // Template 1: SMS.
+        String notificationChannel1 = NotificationChannels.SMS_CHANNEL.getChannelType();
+        String expectedErrorCode3 = IdentityMgtConstants.ErrorMessages.ERROR_CODE_INVALID_SMS_TEMPLATE_CONTENT
+                .getCode();
+        byte[] templateContent1 = "[\"subject\",\"body\",\"footer\"]".getBytes(charsetName);
+
+        // Template 2: EMAIL.
+        String notificationChannel2 = NotificationChannels.EMAIL_CHANNEL.getChannelType();
+        byte[] templateContent2 = "[\"body\"]".getBytes(charsetName);
+        String expectedErrorCode4 = IdentityMgtConstants.ErrorMessages.ERROR_CODE_INVALID_EMAIL_TEMPLATE_CONTENT
+                .getCode();
+
+        // No content in the EMAIL template.
+        String notificationChannel3 = NotificationChannels.EMAIL_CHANNEL.getChannelType();
+        String expectedErrorCode5 = IdentityMgtConstants.ErrorMessages.ERROR_CODE_NO_CONTENT_IN_TEMPLATE
+                .getCode();
+
+        // Invalid application UUID.
+        String applicationUuid = "test-invalid-uuid";
+        String errorMsg3 = "Invalid template locale : ";
+        String expectedErrorCode6 =
+                IdentityMgtConstants.ErrorMessages.ERROR_CODE_NO_CONTENT_IN_TEMPLATE.getCode();
+
+        return new Object[][] {
+                { StringUtils.EMPTY, notificationTemplateType, notificationTemplateType, locale,
+                  StringUtils.EMPTY, false, true, errorMsg1, expectedErrorCode1, null, null },
+                { StringUtils.EMPTY, notificationTemplateType, notificationTemplateType, locale,
+                  StringUtils.EMPTY, true, false, errorMsg2, expectedErrorCode2, null, null },
+                { notificationChannel1, notificationTemplateType, notificationTemplateType, locale,
+                  StringUtils.EMPTY, true, true, StringUtils.EMPTY, expectedErrorCode3, templateContent1, null },
+                { notificationChannel2, notificationTemplateType, notificationTemplateType, locale,
+                  contentType, true, true, StringUtils.EMPTY, expectedErrorCode4, templateContent2, null },
+                { notificationChannel3, notificationTemplateType, notificationTemplateType, locale,
+                  contentType, true, true, StringUtils.EMPTY, expectedErrorCode5, null, null },
+                { StringUtils.EMPTY, notificationTemplateType, notificationTemplateType, locale,
+                StringUtils.EMPTY, true, true, errorMsg3, expectedErrorCode6, null, applicationUuid },
+        };
+    }
+
+    /**
+     * Build a NotificationTemplate model from the given input parameters.
+     * NOTE: parameter order : displayName, channel, type, contentType, locale, body, subject, footer
+     *
+     * @return Notification Template model
+     */
+    private NotificationTemplate buildSampleNotificationTemplate(String[] templateContent) {
+
+        NotificationTemplate notificationTemplate = new NotificationTemplate();
+        notificationTemplate.setNotificationChannel(templateContent[1]);
+        notificationTemplate.setDisplayName(templateContent[0]);
+        notificationTemplate.setType(templateContent[2]);
+        notificationTemplate.setContentType(templateContent[3]);
+        notificationTemplate.setLocale(templateContent[4]);
+        notificationTemplate.setFooter(templateContent[7]);
+        notificationTemplate.setBody(templateContent[5]);
+        notificationTemplate.setSubject(templateContent[6]);
+        return notificationTemplate;
+    }
+
+    /**
+     * Mock registry resource for notification template.
+     *
+     * @param notificationChannel Notification channel
+     * @param displayName         Notification template displayName
+     * @param templateType        Notification template type
+     * @param locale              Notification template locale
+     * @param contentType         Notification template content type
+     * @param templateContent     Notification template content (Subject,body,footer etc)
+     * @throws Exception Error mocking notification template
+     */
+    private void mockRegistryResource(String notificationChannel, String displayName, String templateType,
+                                      String locale, String contentType, byte[] templateContent) throws Exception {
+
+        when(resourceMgtService.getIdentityResource(Matchers.anyString(), Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(resource);
+
+        // Mock Resource properties.
+        when(resource.getProperty(I18nMgtConstants.TEMPLATE_TYPE_DISPLAY_NAME)).thenReturn(displayName);
+        when(resource.getProperty(I18nMgtConstants.TEMPLATE_TYPE)).thenReturn(templateType);
+        when(resource.getProperty(I18nMgtConstants.TEMPLATE_LOCALE)).thenReturn(locale);
+        if (NotificationChannels.EMAIL_CHANNEL.getChannelType().equals(notificationChannel)) {
+            when(resource.getProperty(I18nMgtConstants.TEMPLATE_CONTENT_TYPE)).thenReturn(contentType);
+        }
+        when(resource.getContent()).thenReturn(templateContent);
+    }
+
+    /**
+     * Mocks IdentityValidationUtil template validation methos.
+     *
+     * @param isValidTemplate Whether the template is valid or not
+     * @param isValidLocale   Whether the locate is valid or not
+     */
+    private void mockIsValidTemplate(boolean isValidTemplate, boolean isValidLocale) {
+
+        mockStatic(IdentityValidationUtil.class);
+
+        // Mock methods in validateTemplateType method.
+        when(IdentityValidationUtil
+                .isValid(Matchers.anyString(), Matchers.any(String[].class), Matchers.any(String[].class)))
+                .thenReturn(isValidTemplate);
+
+        // Mock methods in validateLocale method.
+        when(IdentityValidationUtil.isValidOverBlackListPatterns(Matchers.anyString(), Matchers.anyString())).
+                thenReturn(isValidLocale);
+    }
+}

--- a/components/email-mgt/org.wso2.carbon.email.mgt/src/test/java/org/wso2/carbon/email/mgt/OrganizationEmailTemplateTest.java
+++ b/components/email-mgt/org.wso2.carbon.email.mgt/src/test/java/org/wso2/carbon/email/mgt/OrganizationEmailTemplateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2019-2024, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,6 @@
 package org.wso2.carbon.email.mgt;
 
 import static org.mockito.MockitoAnnotations.initMocks;
-import static org.powermock.api.mockito.PowerMockito.doCallRealMethod;
-import static org.powermock.api.mockito.PowerMockito.doNothing;
 import static org.powermock.api.mockito.PowerMockito.mock;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
@@ -26,8 +24,6 @@ import org.apache.axiom.om.impl.builder.StAXOMBuilder;
 import org.apache.commons.lang.StringUtils;
 import org.mockito.Matchers;
 import org.mockito.Mock;
-import org.osgi.framework.BundleContext;
-import org.osgi.service.component.ComponentContext;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.testng.PowerMockTestCase;
@@ -70,7 +66,7 @@ import javax.xml.stream.XMLStreamReader;
  * Class that contains the test cases for the implementation of Email Template Manager.
  */
 @PrepareForTest({ IdentityValidationUtil.class, I18nMgtDataHolder.class, CarbonUtils.class})
-public class EmailTemplateManagerImplTest extends PowerMockTestCase {
+public class OrganizationEmailTemplateTest extends PowerMockTestCase {
 
     private EmailTemplateManagerImpl emailTemplateManager;
 

--- a/components/email-mgt/org.wso2.carbon.email.mgt/src/test/resources/testng.xml
+++ b/components/email-mgt/org.wso2.carbon.email.mgt/src/test/resources/testng.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~ Copyright (c) 2017-2024, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -20,7 +20,8 @@
 
     <test name="EmailMgtTests" preserve-order="true" parallel="false">
         <classes>
-            <class name="org.wso2.carbon.email.mgt.EmailTemplateManagerImplTest"/>
+            <class name="org.wso2.carbon.email.mgt.OrganizationEmailTemplateTest"/>
+            <class name="org.wso2.carbon.email.mgt.ApplicationEmailTemplateTest"/>
             <class name="org.wso2.carbon.email.mgt.util.I18nEmailUtilTest"/>
         </classes>
     </test>

--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/pom.xml
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/pom.xml
@@ -178,6 +178,8 @@
                             org.wso2.carbon.identity.event.event; version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.event.handler; version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.application.authentication.framework.config; version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.application.mgt;version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.application.common.*; version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.event.output.adapter.core.*; version="${carbon.analytics.common.version.range}",
                             org.wso2.carbon.event.stream.core.*; version="${carbon.analytics.common.version.range}",
                             org.wso2.carbon.event.publisher.core.*; version="${carbon.analytics.common.version.range}",

--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/internal/NotificationHandlerDataHolder.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/internal/NotificationHandlerDataHolder.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2016-2024, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -20,6 +20,7 @@ package org.wso2.carbon.identity.event.handler.notification.internal;
 
 import org.wso2.carbon.event.publisher.core.EventPublisherService;
 import org.wso2.carbon.event.stream.core.EventStreamService;
+import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.governance.service.notification.NotificationTemplateManager;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.registry.core.service.RegistryService;
@@ -37,6 +38,17 @@ public class NotificationHandlerDataHolder {
     private EmailTemplateManager emailTemplateManager = null;
     private NotificationTemplateManager notificationTemplateManager = null;
     private OrganizationManager organizationManager;
+    private ApplicationManagementService applicationManagementService;
+
+    public ApplicationManagementService getApplicationManagementService() {
+
+        return applicationManagementService;
+    }
+
+    public void setApplicationManagementService(ApplicationManagementService applicationManagementService) {
+
+        this.applicationManagementService = applicationManagementService;
+    }
 
     private NotificationHandlerDataHolder() {
 

--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/internal/NotificationHandlerServiceComponent.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/internal/NotificationHandlerServiceComponent.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2016-2024, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -22,6 +22,7 @@ import org.apache.commons.logging.LogFactory;
 import org.osgi.service.component.ComponentContext;
 import org.wso2.carbon.event.publisher.core.EventPublisherService;
 import org.wso2.carbon.event.stream.core.EventStreamService;
+import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.event.handler.AbstractEventHandler;
 import org.wso2.carbon.identity.event.handler.notification.DefaultNotificationHandler;
 import org.wso2.carbon.identity.event.handler.notification.NotificationHandler;
@@ -211,6 +212,27 @@ public class NotificationHandlerServiceComponent {
     protected void unsetOrganizationManager(OrganizationManager organizationManager) {
 
         NotificationHandlerDataHolder.getInstance().setOrganizationManager(null);
+    }
+
+    @Reference(name = "application.mgt.service",
+            service = ApplicationManagementService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetApplicationManagementService")
+    protected void setApplicationManagementService(ApplicationManagementService applicationManagementService) {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Setting the Application Management Service.");
+        }
+        NotificationHandlerDataHolder.getInstance().setApplicationManagementService(applicationManagementService);
+    }
+
+    protected void unsetApplicationManagementService(ApplicationManagementService applicationManagementService) {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Un-setting the Application Management Service.");
+        }
+        NotificationHandlerDataHolder.getInstance().setApplicationManagementService(null);
     }
 }
 

--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/util/NotificationUtil.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/util/NotificationUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2016-2024, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except
@@ -34,6 +34,7 @@ import org.wso2.carbon.event.publisher.core.exception.EventPublisherConfiguratio
 import org.wso2.carbon.event.stream.core.EventStreamService;
 import org.wso2.carbon.event.stream.core.exception.EventStreamConfigurationException;
 import org.wso2.carbon.identity.application.authentication.framework.config.ConfigurationFacade;
+import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
 import org.wso2.carbon.identity.branding.preference.management.core.BrandingPreferenceManager;
 import org.wso2.carbon.identity.branding.preference.management.core.BrandingPreferenceManagerImpl;
 import org.wso2.carbon.identity.branding.preference.management.core.constant.BrandingPreferenceMgtConstants;
@@ -63,7 +64,6 @@ import org.wso2.carbon.user.api.UserStoreManager;
 import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
 import org.wso2.carbon.user.core.service.RealmService;
-import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
 import javax.xml.namespace.QName;
 import java.util.ArrayList;
@@ -181,7 +181,23 @@ public class NotificationUtil {
      * @return Place holder data
      */
     public static Map<String, String> getPlaceholderValues(EmailTemplate emailTemplate,
-                                                           Map<String, String> placeHolderData, Map<String, String> userClaims) {
+                                                           Map<String, String> placeHolderData,
+                                                           Map<String, String> userClaims) {
+
+        return getPlaceholderValues(emailTemplate, placeHolderData, userClaims, null);
+    }
+
+    /**
+     * Set placeholder values for email templates with app level branding.
+     *
+     * @param emailTemplate   {@link org.wso2.carbon.email.mgt.model.EmailTemplate}
+     * @param placeHolderData List of placeholder data
+     * @param userClaims      List of user claims
+     * @return Place holder data
+     */
+    public static Map<String, String> getPlaceholderValues(EmailTemplate emailTemplate,
+                                                           Map<String, String> placeHolderData,
+                                                           Map<String, String> userClaims, String applicationUuid) {
 
         Map<String, String> configFilePlaceholders = getConfigFilePlaceholders();
 
@@ -192,11 +208,16 @@ public class NotificationUtil {
                 IdentityUtil.getProperty(NotificationConstants.EmailNotification.ENABLE_ORGANIZATION_LEVEL_EMAIL_BRANDING))) {
             try {
                 BrandingPreferenceManager brandingPreferenceManager = new BrandingPreferenceManagerImpl();
-                BrandingPreference responseDTO = brandingPreferenceManager.resolveBrandingPreference(
-                        BrandingPreferenceMgtConstants.ORGANIZATION_TYPE,
-                        placeHolderData.get(TENANT_DOMAIN),
-                        BrandingPreferenceMgtConstants.DEFAULT_LOCALE);
-
+                BrandingPreference responseDTO;
+                if (StringUtils.isNotBlank(applicationUuid)) {
+                    responseDTO = brandingPreferenceManager.resolveApplicationBrandingPreference(applicationUuid,
+                            BrandingPreferenceMgtConstants.DEFAULT_LOCALE);
+                } else {
+                    responseDTO = brandingPreferenceManager.resolveBrandingPreference(
+                            BrandingPreferenceMgtConstants.ORGANIZATION_TYPE,
+                            placeHolderData.get(TENANT_DOMAIN),
+                            BrandingPreferenceMgtConstants.DEFAULT_LOCALE);
+                }
                 ObjectMapper objectMapper = new ObjectMapper();
                 String json = objectMapper.writeValueAsString(responseDTO.getPreference());
                 brandingPreferences = objectMapper.readTree(json);
@@ -651,8 +672,26 @@ public class NotificationUtil {
         }
 
         EmailTemplate emailTemplate;
+        String applicationUuid = null;
         try {
-            emailTemplate = NotificationHandlerDataHolder.getInstance().getEmailTemplateManager().getEmailTemplate(notificationEvent, locale, tenantDomain);
+            if (event.getEventProperties().containsKey("serviceProviderName")) {
+                String applicationName = event.getEventProperties().get("serviceProviderName").toString();
+                try {
+                    applicationUuid = NotificationHandlerDataHolder.getInstance().getApplicationManagementService()
+                            .getApplicationBasicInfoByName(applicationName, tenantDomain).getApplicationResourceId();
+                } catch (IdentityApplicationManagementException e) {
+                    // Fallback to organization preference if application is not found.
+                }
+            }
+            if (NotificationHandlerDataHolder.getInstance().getEmailTemplateManager().isEmailTemplateExists(
+                    notificationEvent, locale, tenantDomain, applicationUuid)) {
+                emailTemplate = NotificationHandlerDataHolder.getInstance().getEmailTemplateManager()
+                        .getEmailTemplate(notificationEvent, locale, tenantDomain, applicationUuid);
+            } else {
+                // Fallback to organization level email template if application level template is not found.
+                emailTemplate = NotificationHandlerDataHolder.getInstance().getEmailTemplateManager()
+                        .getEmailTemplate(notificationEvent, locale, tenantDomain);
+            }
         } catch (I18nEmailMgtException e) {
             String message = "Error when retrieving template from tenant registry.";
             throw NotificationRuntimeException.error(message, e);
@@ -662,7 +701,7 @@ public class NotificationUtil {
         int currentYear = Calendar.getInstance().get(Calendar.YEAR);
         placeHolderData.put("current-year", String.valueOf(currentYear));
 
-        NotificationUtil.getPlaceholderValues(emailTemplate, placeHolderData, userClaims);
+        NotificationUtil.getPlaceholderValues(emailTemplate, placeHolderData, userClaims, applicationUuid);
 
         if (StringUtils.isBlank(placeHolderData.get(ORGANIZATION_NAME_PLACEHOLDER))) {
             // If the organization display name is not configured with branding,

--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/util/NotificationUtil.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/util/NotificationUtil.java
@@ -104,6 +104,7 @@ public class NotificationUtil {
     private static final Log log = LogFactory.getLog(NotificationUtil.class);
 
     private static final String USER_IDENTITY_CLAIMS = "UserIdentityClaims";
+    private static final String SERVICE_PROVIDER_NAME = "serviceProviderName";
     public static final String CALLER_PATH_PLACEHOLDER = "caller.path";
     public static final String MAGIC_LINK = "magicLink";
     public static final String CALLBACK_URL = "callbackUrl";
@@ -674,13 +675,15 @@ public class NotificationUtil {
         EmailTemplate emailTemplate;
         String applicationUuid = null;
         try {
-            if (event.getEventProperties().containsKey("serviceProviderName")) {
-                String applicationName = event.getEventProperties().get("serviceProviderName").toString();
+            if (event.getEventProperties().containsKey(SERVICE_PROVIDER_NAME)) {
+                String applicationName = event.getEventProperties().get(SERVICE_PROVIDER_NAME).toString();
                 try {
                     applicationUuid = NotificationHandlerDataHolder.getInstance().getApplicationManagementService()
                             .getApplicationBasicInfoByName(applicationName, tenantDomain).getApplicationResourceId();
                 } catch (IdentityApplicationManagementException e) {
                     // Fallback to organization preference if application is not found.
+                    log.warn("Fallback to organization preference. Cannot get application id for application name: " +
+                            applicationName, e);
                 }
             }
             if (NotificationHandlerDataHolder.getInstance().getEmailTemplateManager().isEmailTemplateExists(

--- a/pom.xml
+++ b/pom.xml
@@ -392,7 +392,7 @@
 
     <properties>
         <!--Identity Governance Version-->
-        <identity.governance.version>1.5.77</identity.governance.version>
+        <identity.governance.version>1.9.8</identity.governance.version>
         <identity.governance.imp.pkg.version.range>[1.0.0, 3.0.0)</identity.governance.imp.pkg.version.range>
 
         <!--Identity Event Handler Email Version-->
@@ -402,7 +402,7 @@
         <osgi.framework.imp.pkg.version.range>[1.7.0, 2.0.0)</osgi.framework.imp.pkg.version.range>
         <osgi.service.component.imp.pkg.version.range>[1.2.0, 2.0.0)</osgi.service.component.imp.pkg.version.range>
 
-        <identity.branding.preference.management.version>1.0.8</identity.branding.preference.management.version>
+        <identity.branding.preference.management.version>1.1.5</identity.branding.preference.management.version>
         <identity.branding.preference.management.version.range>[1.0.1, 2.0.0)</identity.branding.preference.management.version.range>
 
         <!--Orbit Version-->


### PR DESCRIPTION
### Description
Introduce application UUID to the following methods to cater application specific email templates in EmailTemplateManager.
- getEmailTemplateType
- addEmailTemplate
- deleteEmailTemplate
- getEmailTemplate
- isEmailTemplateExists

Application email template resolving for notification handler is also added here.

### Related issue
- https://github.com/wso2/product-is/issues/19853

### Todo
- [x]  Bump `identity-governance` version from https://github.com/wso2-extensions/identity-governance/pull/811
