### PR TITLE
Decouple EmailTemplateManager service logic from the storage logic

### DIFF
--- a/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/EmailTemplateManagerImpl.java
+++ b/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/EmailTemplateManagerImpl.java
@@ -16,12 +16,12 @@
 
 package org.wso2.carbon.email.mgt;
 
-import com.google.gson.Gson;
-import com.google.gson.JsonSyntaxException;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.email.mgt.constants.I18nMgtConstants;
+import org.wso2.carbon.email.mgt.dao.RegistryBasedTemplateManager;
+import org.wso2.carbon.email.mgt.dao.TemplatePersistenceManager;
 import org.wso2.carbon.email.mgt.exceptions.I18nEmailMgtClientException;
 import org.wso2.carbon.email.mgt.exceptions.I18nEmailMgtException;
 import org.wso2.carbon.email.mgt.exceptions.I18nEmailMgtInternalException;
@@ -30,9 +30,7 @@ import org.wso2.carbon.email.mgt.exceptions.I18nMgtEmailConfigException;
 import org.wso2.carbon.email.mgt.internal.I18nMgtDataHolder;
 import org.wso2.carbon.email.mgt.model.EmailTemplate;
 import org.wso2.carbon.email.mgt.util.I18nEmailUtil;
-import org.wso2.carbon.identity.base.IdentityRuntimeException;
 import org.wso2.carbon.identity.base.IdentityValidationUtil;
-import org.wso2.carbon.identity.core.persistence.registry.RegistryResourceMgtService;
 import org.wso2.carbon.identity.governance.IdentityGovernanceUtil;
 import org.wso2.carbon.identity.governance.IdentityMgtConstants;
 import org.wso2.carbon.identity.governance.exceptions.notiification.NotificationTemplateManagerClientException;
@@ -42,37 +40,25 @@ import org.wso2.carbon.identity.governance.exceptions.notiification.Notification
 import org.wso2.carbon.identity.governance.model.NotificationTemplate;
 import org.wso2.carbon.identity.governance.service.notification.NotificationChannels;
 import org.wso2.carbon.identity.governance.service.notification.NotificationTemplateManager;
-import org.wso2.carbon.registry.core.Collection;
-import org.wso2.carbon.registry.core.RegistryConstants;
-import org.wso2.carbon.registry.core.Resource;
-import org.wso2.carbon.registry.core.ResourceImpl;
-import org.wso2.carbon.registry.core.exceptions.RegistryException;
 
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.wso2.carbon.email.mgt.constants.I18nMgtConstants.APP_TEMPLATE_PATH;
 import static org.wso2.carbon.email.mgt.constants.I18nMgtConstants.DEFAULT_EMAIL_LOCALE;
 import static org.wso2.carbon.email.mgt.constants.I18nMgtConstants.DEFAULT_SMS_NOTIFICATION_LOCALE;
 import static org.wso2.carbon.email.mgt.constants.I18nMgtConstants.EMAIL_TEMPLATE_NAME;
-import static org.wso2.carbon.email.mgt.constants.I18nMgtConstants.EMAIL_TEMPLATE_PATH;
-import static org.wso2.carbon.email.mgt.constants.I18nMgtConstants.EMAIL_TEMPLATE_TYPE_DISPLAY_NAME;
 import static org.wso2.carbon.email.mgt.constants.I18nMgtConstants.EMAIL_TEMPLATE_TYPE_REGEX;
 import static org.wso2.carbon.email.mgt.constants.I18nMgtConstants.ErrorCodes.EMAIL_TEMPLATE_TYPE_NOT_FOUND;
-import static org.wso2.carbon.email.mgt.constants.I18nMgtConstants.SMS_TEMPLATE_PATH;
 import static org.wso2.carbon.email.mgt.util.I18nEmailUtil.buildEmailTemplate;
+import static org.wso2.carbon.email.mgt.util.I18nEmailUtil.buildNotificationTemplateFromEmailTemplate;
 import static org.wso2.carbon.identity.base.IdentityValidationUtil.ValidatorPattern.REGISTRY_INVALID_CHARS_EXISTS;
-import static org.wso2.carbon.registry.core.RegistryConstants.PATH_SEPARATOR;
 
 /**
  * Provides functionality to manage email templates used in notification emails.
  */
 public class EmailTemplateManagerImpl implements EmailTemplateManager, NotificationTemplateManager {
 
-    private I18nMgtDataHolder dataHolder = I18nMgtDataHolder.getInstance();
-    private RegistryResourceMgtService resourceMgtService = dataHolder.getRegistryResourceMgtService();
+    private TemplatePersistenceManager templatePersistenceManager = new RegistryBasedTemplateManager();
 
     private static final Log log = LogFactory.getLog(EmailTemplateManagerImpl.class);
 
@@ -120,13 +106,10 @@ public class EmailTemplateManagerImpl implements EmailTemplateManager, Notificat
             throws NotificationTemplateManagerException {
 
         validateDisplayNameOfTemplateType(displayName);
-        String normalizedDisplayName = I18nEmailUtil.getNormalizedName(displayName);
 
-        // Persist the template type to registry ie. create a directory.
-        String path = buildTemplateRootDirectoryPath(normalizedDisplayName, notificationChannel, applicationUuid);
         try {
-            // Check whether a template exists with the same name.
-            if (resourceMgtService.isResourceExists(path, tenantDomain)) {
+            if (templatePersistenceManager.isNotificationTemplateTypeExists(displayName, notificationChannel,
+                    tenantDomain)) {
                 String code = I18nEmailUtil.prependOperationScenarioToErrorCode(
                         I18nMgtConstants.ErrorMessages.ERROR_CODE_DUPLICATE_TEMPLATE_TYPE.getCode(),
                         I18nMgtConstants.ErrorScenarios.EMAIL_TEMPLATE_MANAGER);
@@ -135,9 +118,8 @@ public class EmailTemplateManagerImpl implements EmailTemplateManager, Notificat
                                 displayName, tenantDomain);
                 throw new NotificationTemplateManagerInternalException(code, message);
             }
-            Collection collection = I18nEmailUtil.createTemplateType(normalizedDisplayName, displayName);
-            resourceMgtService.putIdentityResource(collection, path, tenantDomain);
-        } catch (IdentityRuntimeException ex) {
+            templatePersistenceManager.addNotificationTemplateType(displayName, notificationChannel, tenantDomain);
+        } catch (NotificationTemplateManagerServerException e) {
             String code = I18nEmailUtil.prependOperationScenarioToErrorCode(
                     I18nMgtConstants.ErrorMessages.ERROR_CODE_ERROR_ADDING_TEMPLATE.getCode(),
                     I18nMgtConstants.ErrorScenarios.EMAIL_TEMPLATE_MANAGER);
@@ -154,12 +136,10 @@ public class EmailTemplateManagerImpl implements EmailTemplateManager, Notificat
 
         validateTemplateType(emailTemplateDisplayName, tenantDomain);
 
-        String templateType = I18nEmailUtil.getNormalizedName(emailTemplateDisplayName);
-        String path = EMAIL_TEMPLATE_PATH + PATH_SEPARATOR + templateType;
-
         try {
-            resourceMgtService.deleteIdentityResource(path, tenantDomain);
-        } catch (IdentityRuntimeException ex) {
+            templatePersistenceManager.deleteNotificationTemplateType(emailTemplateDisplayName,
+                    NotificationChannels.EMAIL_CHANNEL.getChannelType(), tenantDomain);
+        } catch (NotificationTemplateManagerException ex) {
             String errorMsg = String.format
                     ("Error deleting email template type %s from %s tenant.", emailTemplateDisplayName, tenantDomain);
             handleServerException(errorMsg, ex);
@@ -175,19 +155,9 @@ public class EmailTemplateManagerImpl implements EmailTemplateManager, Notificat
     public List<String> getAvailableTemplateTypes(String tenantDomain) throws I18nEmailMgtServerException {
 
         try {
-            List<String> templateTypeList = new ArrayList<>();
-            Collection collection = (Collection) resourceMgtService.getIdentityResource(EMAIL_TEMPLATE_PATH,
-                    tenantDomain);
-
-            for (String templatePath : collection.getChildren()) {
-                Resource templateTypeResource = resourceMgtService.getIdentityResource(templatePath, tenantDomain);
-                if (templateTypeResource != null) {
-                    String emailTemplateType = templateTypeResource.getProperty(EMAIL_TEMPLATE_TYPE_DISPLAY_NAME);
-                    templateTypeList.add(emailTemplateType);
-                }
-            }
-            return templateTypeList;
-        } catch (IdentityRuntimeException | RegistryException ex) {
+            return templatePersistenceManager.listNotificationTemplateTypes(
+                    NotificationChannels.EMAIL_CHANNEL.getChannelType(), tenantDomain);
+        } catch (NotificationTemplateManagerServerException ex) {
             String errorMsg = String.format("Error when retrieving email template types of %s tenant.", tenantDomain);
             throw new I18nEmailMgtServerException(errorMsg, ex);
         }
@@ -196,24 +166,14 @@ public class EmailTemplateManagerImpl implements EmailTemplateManager, Notificat
     @Override
     public List<EmailTemplate> getAllEmailTemplates(String tenantDomain) throws I18nEmailMgtException {
 
-        List<EmailTemplate> templateList = new ArrayList<>();
-
         try {
-            Collection baseDirectory = (Collection) resourceMgtService.getIdentityResource(EMAIL_TEMPLATE_PATH,
-                    tenantDomain);
-
-            if (baseDirectory != null) {
-                for (String templateTypeDirectory : baseDirectory.getChildren()) {
-                    templateList.addAll(
-                            getAllTemplatesOfTemplateTypeFromRegistry(templateTypeDirectory, tenantDomain));
-                }
-            }
-        } catch (RegistryException | IdentityRuntimeException e) {
+            List<NotificationTemplate> notificationTemplates = templatePersistenceManager.listAllNotificationTemplates(
+                    NotificationChannels.EMAIL_CHANNEL.getChannelType(), tenantDomain);
+            return getEmailTemplateList(notificationTemplates);
+        } catch (NotificationTemplateManagerServerException e) {
             String error = String.format("Error when retrieving email templates of %s tenant.", tenantDomain);
             throw new I18nEmailMgtServerException(error, e);
         }
-
-        return templateList;
     }
 
     @Override
@@ -235,12 +195,21 @@ public class EmailTemplateManagerImpl implements EmailTemplateManager, Notificat
             String templateDisplayName, String tenantDomain, String applicationUuid) throws I18nEmailMgtException {
 
         validateTemplateType(templateDisplayName, tenantDomain);
-        String templateDirectory = I18nEmailUtil.getNormalizedName(templateDisplayName);
-        String templateTypeRegistryPath =
-                EMAIL_TEMPLATE_PATH + PATH_SEPARATOR + templateDirectory + getApplicationPath(applicationUuid);
+
         try {
-            return getAllTemplatesOfTemplateTypeFromRegistry(templateTypeRegistryPath, tenantDomain);
-        } catch (RegistryException ex) {
+            if (!templatePersistenceManager.isNotificationTemplateTypeExists(templateDisplayName,
+                    NotificationChannels.EMAIL_CHANNEL.getChannelType(), tenantDomain)) {
+                String message =
+                        String.format("Email Template Type: %s not found in %s tenant registry.", templateDisplayName,
+                                tenantDomain);
+                throw new I18nEmailMgtClientException(EMAIL_TEMPLATE_TYPE_NOT_FOUND, message);
+            }
+
+            List<NotificationTemplate> notificationTemplates =
+                    templatePersistenceManager.listNotificationTemplates(templateDisplayName,
+                            NotificationChannels.EMAIL_CHANNEL.getChannelType(), applicationUuid, tenantDomain);
+            return getEmailTemplateList(notificationTemplates);
+        } catch (NotificationTemplateManagerServerException ex) {
             String error = "Error when retrieving '%s' template type from %s tenant registry.";
             throw new I18nEmailMgtServerException(String.format(error, templateDisplayName, tenantDomain), ex);
         }
@@ -263,44 +232,21 @@ public class EmailTemplateManagerImpl implements EmailTemplateManager, Notificat
 
     @Override
     public NotificationTemplate getNotificationTemplate(String notificationChannel, String templateType, String locale,
-            String tenantDomain) throws NotificationTemplateManagerException {
+                                                        String tenantDomain) throws NotificationTemplateManagerException {
 
         return getNotificationTemplate(notificationChannel, templateType, locale, tenantDomain, null);
     }
 
     @Override
     public NotificationTemplate getNotificationTemplate(String notificationChannel, String templateType, String locale,
-            String tenantDomain, String applicationUuid) throws NotificationTemplateManagerException {
+                                                        String tenantDomain, String applicationUuid) throws NotificationTemplateManagerException {
 
         // Resolve channel to either SMS or EMAIL.
         notificationChannel = resolveNotificationChannel(notificationChannel);
         validateTemplateLocale(locale);
         validateDisplayNameOfTemplateType(templateType);
-        NotificationTemplate notificationTemplate = null;
-
-        // Get notification template registry path.
-        String path;
-        if (NotificationChannels.SMS_CHANNEL.getChannelType().equals(notificationChannel)) {
-            path = SMS_TEMPLATE_PATH + PATH_SEPARATOR + I18nEmailUtil.getNormalizedName(templateType);
-        } else {
-            path = EMAIL_TEMPLATE_PATH + PATH_SEPARATOR + I18nEmailUtil.getNormalizedName(templateType) +
-                    getApplicationPath(applicationUuid);
-        }
-
-        // Get registry resource.
-        try {
-            Resource registryResource = resourceMgtService.getIdentityResource(path, tenantDomain, locale);
-            if (registryResource != null) {
-                notificationTemplate = getNotificationTemplate(registryResource, notificationChannel);
-            }
-        } catch (IdentityRuntimeException exception) {
-            String error = String
-                    .format(IdentityMgtConstants.ErrorMessages.ERROR_CODE_ERROR_RETRIEVING_TEMPLATE_FROM_REGISTRY
-                            .getMessage(), templateType, locale, tenantDomain);
-            throw new NotificationTemplateManagerServerException(
-                    IdentityMgtConstants.ErrorMessages.ERROR_CODE_ERROR_RETRIEVING_TEMPLATE_FROM_REGISTRY.getCode(),
-                    error, exception);
-        }
+        NotificationTemplate notificationTemplate = templatePersistenceManager.getNotificationTemplate(templateType,
+                locale, notificationChannel, applicationUuid, tenantDomain);
 
         // Handle not having the requested SMS template type in required locale for this tenantDomain.
         if (notificationTemplate == null) {
@@ -319,7 +265,7 @@ public class EmailTemplateManagerImpl implements EmailTemplateManager, Notificat
                     String message = String
                             .format("'%s' template in '%s' locale was not found in '%s' tenant. Trying to return the "
                                             + "template in default locale : '%s'", templateType, locale, tenantDomain,
-                                    DEFAULT_SMS_NOTIFICATION_LOCALE);
+                                    defaultLocale);
                     log.debug(message);
                 }
                 // Try to get the template type in default locale.
@@ -327,111 +273,6 @@ public class EmailTemplateManagerImpl implements EmailTemplateManager, Notificat
             }
         }
         return notificationTemplate;
-    }
-
-    /**
-     * Get the notification template from resource.
-     *
-     * @param templateResource    {@link org.wso2.carbon.registry.core.Resource} object
-     * @param notificationChannel Notification channel
-     * @return {@link org.wso2.carbon.identity.governance.model.NotificationTemplate} object
-     * @throws NotificationTemplateManagerException Error getting the notification template
-     */
-    private NotificationTemplate getNotificationTemplate(Resource templateResource, String notificationChannel)
-            throws NotificationTemplateManagerException {
-
-        NotificationTemplate notificationTemplate = new NotificationTemplate();
-
-        // Get template meta properties.
-        String displayName = templateResource.getProperty(I18nMgtConstants.TEMPLATE_TYPE_DISPLAY_NAME);
-        String type = templateResource.getProperty(I18nMgtConstants.TEMPLATE_TYPE);
-        String locale = templateResource.getProperty(I18nMgtConstants.TEMPLATE_LOCALE);
-        if (NotificationChannels.EMAIL_CHANNEL.getChannelType().equals(notificationChannel)) {
-            String contentType = templateResource.getProperty(I18nMgtConstants.TEMPLATE_CONTENT_TYPE);
-
-            // Setting UTF-8 for all the email templates as it supports many languages and is widely adopted.
-            // There is little to no value addition making the charset configurable.
-            if (contentType != null && !contentType.toLowerCase().contains(I18nEmailUtil.CHARSET_CONSTANT)) {
-                contentType = contentType + "; " + I18nEmailUtil.CHARSET_UTF_8;
-            }
-            notificationTemplate.setContentType(contentType);
-        }
-        notificationTemplate.setDisplayName(displayName);
-        notificationTemplate.setType(type);
-        notificationTemplate.setLocale(locale);
-
-        // Process template content.
-        String[] templateContentElements = getTemplateElements(templateResource, notificationChannel, displayName,
-                locale);
-        if (NotificationChannels.SMS_CHANNEL.getChannelType().equals(notificationChannel)) {
-            notificationTemplate.setBody(templateContentElements[0]);
-        } else {
-            notificationTemplate.setSubject(templateContentElements[0]);
-            notificationTemplate.setBody(templateContentElements[1]);
-            notificationTemplate.setFooter(templateContentElements[2]);
-        }
-        notificationTemplate.setNotificationChannel(notificationChannel);
-        return notificationTemplate;
-    }
-
-    /**
-     * Process template resource content and retrieve template elements.
-     *
-     * @param templateResource    Resource of the template
-     * @param notificationChannel Notification channel
-     * @param displayName         Display name of the template
-     * @param locale              Locale of the template
-     * @return Template content
-     * @throws NotificationTemplateManagerException If an error occurred while getting the template content
-     */
-    private String[] getTemplateElements(Resource templateResource, String notificationChannel, String displayName,
-            String locale) throws NotificationTemplateManagerException {
-
-        try {
-            Object content = templateResource.getContent();
-            if (content != null) {
-                byte[] templateContentArray = (byte[]) content;
-                String templateContent = new String(templateContentArray, Charset.forName("UTF-8"));
-
-                String[] templateContentElements;
-                try {
-                    templateContentElements = new Gson().fromJson(templateContent, String[].class);
-                } catch (JsonSyntaxException exception) {
-                    String error = String.format(IdentityMgtConstants.ErrorMessages.
-                            ERROR_CODE_DESERIALIZING_TEMPLATE_FROM_TENANT_REGISTRY.getMessage(), displayName, locale);
-                    throw new NotificationTemplateManagerServerException(IdentityMgtConstants.ErrorMessages.
-                            ERROR_CODE_DESERIALIZING_TEMPLATE_FROM_TENANT_REGISTRY.getCode(), error, exception);
-                }
-
-                // Validate template content.
-                if (NotificationChannels.SMS_CHANNEL.getChannelType().equals(notificationChannel)) {
-                    if (templateContentElements == null || templateContentElements.length != 1) {
-                        String errorMsg = String.format(IdentityMgtConstants.ErrorMessages.
-                                ERROR_CODE_INVALID_SMS_TEMPLATE_CONTENT.getMessage(), displayName, locale);
-                        throw new NotificationTemplateManagerServerException(IdentityMgtConstants.ErrorMessages.
-                                ERROR_CODE_INVALID_SMS_TEMPLATE_CONTENT.getCode(), errorMsg);
-                    }
-                } else {
-                    if (templateContentElements == null || templateContentElements.length != 3) {
-                        String errorMsg = String.format(IdentityMgtConstants.ErrorMessages.
-                                ERROR_CODE_INVALID_EMAIL_TEMPLATE_CONTENT.getMessage(), displayName, locale);
-                        throw new NotificationTemplateManagerServerException(IdentityMgtConstants.ErrorMessages.
-                                ERROR_CODE_INVALID_EMAIL_TEMPLATE_CONTENT.getCode(), errorMsg);
-                    }
-                }
-                return templateContentElements;
-            } else {
-                String error = String.format(IdentityMgtConstants.ErrorMessages.
-                        ERROR_CODE_NO_CONTENT_IN_TEMPLATE.getMessage(), displayName, locale);
-                throw new NotificationTemplateManagerClientException(IdentityMgtConstants.ErrorMessages.
-                        ERROR_CODE_NO_CONTENT_IN_TEMPLATE.getCode(), error);
-            }
-        } catch (RegistryException exception) {
-            String error = IdentityMgtConstants.ErrorMessages.
-                    ERROR_CODE_ERROR_RETRIEVING_TEMPLATE_OBJECT_FROM_REGISTRY.getMessage();
-            throw new NotificationTemplateManagerServerException(IdentityMgtConstants.ErrorMessages.
-                    ERROR_CODE_ERROR_RETRIEVING_TEMPLATE_OBJECT_FROM_REGISTRY.getCode(), error, exception);
-        }
     }
 
     /**
@@ -457,53 +298,6 @@ public class EmailTemplateManagerImpl implements EmailTemplateManager, Notificat
         }
     }
 
-    /**
-     * Create a registry resource instance of the notification template.
-     *
-     * @param notificationTemplate Notification template
-     * @return Resource
-     * @throws NotificationTemplateManagerServerException If an error occurred while creating the resource
-     */
-    private Resource createTemplateRegistryResource(NotificationTemplate notificationTemplate)
-            throws NotificationTemplateManagerServerException {
-
-        String displayName = notificationTemplate.getDisplayName();
-        String type = I18nEmailUtil.getNormalizedName(displayName);
-        String locale = notificationTemplate.getLocale();
-        String body = notificationTemplate.getBody();
-
-        // Set template properties.
-        Resource templateResource = new ResourceImpl();
-        templateResource.setProperty(I18nMgtConstants.TEMPLATE_TYPE_DISPLAY_NAME, displayName);
-        templateResource.setProperty(I18nMgtConstants.TEMPLATE_TYPE, type);
-        templateResource.setProperty(I18nMgtConstants.TEMPLATE_LOCALE, locale);
-        String[] templateContent;
-        // Handle contents according to different channel types.
-        if (NotificationChannels.EMAIL_CHANNEL.getChannelType().equals(notificationTemplate.getNotificationChannel())) {
-            templateContent = new String[]{notificationTemplate.getSubject(), body, notificationTemplate.getFooter()};
-            templateResource.setProperty(I18nMgtConstants.TEMPLATE_CONTENT_TYPE, notificationTemplate.getContentType());
-        } else {
-            templateContent = new String[]{body};
-        }
-        templateResource.setMediaType(RegistryConstants.TAG_MEDIA_TYPE);
-        String content = new Gson().toJson(templateContent);
-        try {
-            byte[] contentByteArray = content.getBytes(StandardCharsets.UTF_8);
-            templateResource.setContent(contentByteArray);
-        } catch (RegistryException e) {
-            String code =
-                    I18nEmailUtil.prependOperationScenarioToErrorCode(
-                            I18nMgtConstants.ErrorMessages.ERROR_CODE_ERROR_CREATING_REGISTRY_RESOURCE.getCode(),
-                            I18nMgtConstants.ErrorScenarios.EMAIL_TEMPLATE_MANAGER);
-            String message =
-                    String.format(
-                            I18nMgtConstants.ErrorMessages.ERROR_CODE_ERROR_CREATING_REGISTRY_RESOURCE.getMessage(),
-                            displayName, locale);
-            throw new NotificationTemplateManagerServerException(code, message, e);
-        }
-        return templateResource;
-    }
-
     @Override
     public void addNotificationTemplate(NotificationTemplate notificationTemplate, String tenantDomain)
             throws NotificationTemplateManagerException {
@@ -517,26 +311,14 @@ public class EmailTemplateManagerImpl implements EmailTemplateManager, Notificat
             throws NotificationTemplateManagerException {
 
         validateNotificationTemplate(notificationTemplate);
-        String notificationChannel = notificationTemplate.getNotificationChannel();
 
-        Resource templateResource = createTemplateRegistryResource(notificationTemplate);
         String displayName = notificationTemplate.getDisplayName();
-        String type = I18nEmailUtil.getNormalizedName(displayName);
         String locale = notificationTemplate.getLocale();
 
-        String path = buildTemplateRootDirectoryPath(type, notificationChannel, applicationUuid);
         try {
-            // Check whether a template type root directory exists.
-            if (!resourceMgtService.isResourceExists(path, tenantDomain)) {
-                // Add new template type with relevant properties.
-                addNotificationTemplateType(displayName, notificationChannel, tenantDomain, applicationUuid);
-                if (log.isDebugEnabled()) {
-                    String msg = "Creating template type : %s in tenant registry : %s";
-                    log.debug(String.format(msg, displayName, tenantDomain));
-                }
-            }
-            resourceMgtService.putIdentityResource(templateResource, path, tenantDomain, locale);
-        } catch (IdentityRuntimeException e) {
+            templatePersistenceManager.addOrUpdateNotificationTemplate(notificationTemplate, applicationUuid,
+                    tenantDomain);
+        } catch (NotificationTemplateManagerServerException e) {
             String code = I18nEmailUtil.prependOperationScenarioToErrorCode(
                     I18nMgtConstants.ErrorMessages.ERROR_CODE_ERROR_ERROR_ADDING_TEMPLATE.getCode(),
                     I18nMgtConstants.ErrorScenarios.EMAIL_TEMPLATE_MANAGER);
@@ -564,24 +346,7 @@ public class EmailTemplateManagerImpl implements EmailTemplateManager, Notificat
     @Override
     public void deleteEmailTemplates(String templateTypeName, String tenantDomain) throws I18nEmailMgtException {
 
-        validateTemplateType(templateTypeName, tenantDomain);
-
-        String templateType = I18nEmailUtil.getNormalizedName(templateTypeName);
-        String path = EMAIL_TEMPLATE_PATH + PATH_SEPARATOR + templateType;
-
-        try {
-            Collection templates = (Collection) resourceMgtService.getIdentityResource(path, tenantDomain);
-            for (String subPath : templates.getChildren()) {
-                // Exclude the app templates.
-                if (!subPath.contains(APP_TEMPLATE_PATH)) {
-                    resourceMgtService.deleteIdentityResource(subPath, tenantDomain);
-                }
-            }
-        } catch (IdentityRuntimeException | RegistryException ex) {
-            String errorMsg = String.format
-                    ("Error deleting email template type %s from %s tenant.", templateType, tenantDomain);
-            handleServerException(errorMsg, ex);
-        }
+        deleteEmailTemplates(templateTypeName, tenantDomain, null);
     }
 
     @Override
@@ -590,19 +355,12 @@ public class EmailTemplateManagerImpl implements EmailTemplateManager, Notificat
 
         validateTemplateType(templateTypeName, tenantDomain);
 
-        String templateType = I18nEmailUtil.getNormalizedName(templateTypeName);
-        String path = EMAIL_TEMPLATE_PATH + PATH_SEPARATOR + templateType + APP_TEMPLATE_PATH +
-                PATH_SEPARATOR + applicationUuid;
-
         try {
-            if (!resourceMgtService.isResourceExists(path, tenantDomain)) {
-                // No templates found for the given application UUID.
-                return;
-            }
-            resourceMgtService.deleteIdentityResource(path, tenantDomain);
-        } catch (IdentityRuntimeException ex) {
+            templatePersistenceManager.deleteNotificationTemplates(templateTypeName,
+                    NotificationChannels.EMAIL_CHANNEL.getChannelType(), applicationUuid, tenantDomain);
+        } catch (NotificationTemplateManagerServerException ex) {
             String errorMsg = String.format("Error deleting email template type %s from %s tenant for application %s.",
-                    templateType, tenantDomain, applicationUuid);
+                    templateTypeName, tenantDomain, applicationUuid);
             handleServerException(errorMsg, ex);
         }
     }
@@ -647,14 +405,12 @@ public class EmailTemplateManagerImpl implements EmailTemplateManager, Notificat
         try {
             for (NotificationTemplate template : notificationTemplates) {
                 String displayName = template.getDisplayName();
-                String type = I18nEmailUtil.getNormalizedName(displayName);
                 String locale = template.getLocale();
-                String path = buildTemplateRootDirectoryPath(type, notificationChannel);
 
             /*Check for existence of each category, since some template may have migrated from earlier version
             This will also add new template types provided from file, but won't update any existing template*/
-                if (!resourceMgtService.isResourceExists(addLocaleToTemplateTypeResourcePath(path, locale),
-                        tenantDomain)) {
+                if (!templatePersistenceManager.isNotificationTemplateExists(displayName, locale, notificationChannel,
+                        null, tenantDomain)) {
                     try {
                         addNotificationTemplate(template, tenantDomain);
                         if (log.isDebugEnabled()) {
@@ -672,7 +428,7 @@ public class EmailTemplateManagerImpl implements EmailTemplateManager, Notificat
                 log.debug(String.format("Added %d default %s templates to the tenant registry : %s",
                         numberOfAddedTemplates, notificationChannel, tenantDomain));
             }
-        } catch (IdentityRuntimeException ex) {
+        } catch (NotificationTemplateManagerServerException ex) {
             String error = "Error when tried to check for default email templates in tenant registry : %s";
             log.error(String.format(error, tenantDomain), ex);
         }
@@ -704,15 +460,10 @@ public class EmailTemplateManagerImpl implements EmailTemplateManager, Notificat
     public boolean isEmailTemplateExists(String templateTypeDisplayName, String locale,
                                          String tenantDomain, String applicationUuid) throws I18nEmailMgtException {
 
-        // Get template directory name from display name.
-        String normalizedTemplateName = I18nEmailUtil.getNormalizedName(templateTypeDisplayName);
-        String path = EMAIL_TEMPLATE_PATH + PATH_SEPARATOR + normalizedTemplateName +
-                getApplicationPath(applicationUuid) + PATH_SEPARATOR + locale.toLowerCase();
-
         try {
-            Resource template = resourceMgtService.getIdentityResource(path, tenantDomain);
-            return template != null;
-        } catch (IdentityRuntimeException e) {
+            return templatePersistenceManager.isNotificationTemplateExists(templateTypeDisplayName, locale,
+                    NotificationChannels.EMAIL_CHANNEL.getChannelType(), applicationUuid, tenantDomain);
+        } catch (NotificationTemplateManagerServerException e) {
             String error = String.format("Error when retrieving email templates of %s tenant.", tenantDomain);
             throw new I18nEmailMgtServerException(error, e);
         }
@@ -722,14 +473,10 @@ public class EmailTemplateManagerImpl implements EmailTemplateManager, Notificat
     public boolean isEmailTemplateTypeExists(String templateTypeDisplayName, String tenantDomain)
             throws I18nEmailMgtException {
 
-        // get template directory name from display name.
-        String normalizedTemplateName = I18nEmailUtil.getNormalizedName(templateTypeDisplayName);
-        String path = EMAIL_TEMPLATE_PATH + PATH_SEPARATOR + normalizedTemplateName;
-
         try {
-            Resource templateType = resourceMgtService.getIdentityResource(path, tenantDomain);
-            return templateType != null;
-        } catch (IdentityRuntimeException e) {
+            return templatePersistenceManager.isNotificationTemplateTypeExists(templateTypeDisplayName,
+                    NotificationChannels.EMAIL_CHANNEL.getChannelType(), tenantDomain);
+        } catch (NotificationTemplateManagerServerException e) {
             String error = String.format("Error when retrieving email templates of %s tenant.", tenantDomain);
             throw new I18nEmailMgtServerException(error, e);
         }
@@ -771,11 +518,10 @@ public class EmailTemplateManagerImpl implements EmailTemplateManager, Notificat
             throw new I18nEmailMgtClientException("Cannot Delete template. Email locale cannot be null.");
         }
 
-        String templateType = I18nEmailUtil.getNormalizedName(templateTypeName);
-        String path = EMAIL_TEMPLATE_PATH + PATH_SEPARATOR + templateType + getApplicationPath(applicationUuid);
         try {
-            resourceMgtService.deleteIdentityResource(path, tenantDomain, localeCode);
-        } catch (IdentityRuntimeException ex) {
+            templatePersistenceManager.deleteNotificationTemplate(templateTypeName, localeCode,
+                    NotificationChannels.EMAIL_CHANNEL.getChannelType(), applicationUuid, tenantDomain);
+        } catch (NotificationTemplateManagerServerException ex) {
             String msg = String.format("Error deleting %s:%s template from %s tenant registry.", templateTypeName,
                     localeCode, tenantDomain);
             handleServerException(msg, ex);
@@ -817,20 +563,6 @@ public class EmailTemplateManagerImpl implements EmailTemplateManager, Notificat
             }
             throw new I18nEmailMgtServerException(exception.getMessage(), exception.getCause());
         }
-    }
-
-    /**
-     * Build application template path from application UUID or return empty string if application UUID is null.
-     *
-     * @param applicationUuid Application UUID.
-     * @return Application template path.
-     */
-    private String getApplicationPath(String applicationUuid) {
-
-        if (StringUtils.isNotBlank(applicationUuid)) {
-            return APP_TEMPLATE_PATH + PATH_SEPARATOR + applicationUuid;
-        }
-        return StringUtils.EMPTY;
     }
 
     /**
@@ -929,46 +661,6 @@ public class EmailTemplateManagerImpl implements EmailTemplateManager, Notificat
         }
     }
 
-    /**
-     * Loop through all template resources of a given template type registry path and return a list of EmailTemplate
-     * objects.
-     *
-     * @param templateTypeRegistryPath Registry path of the template type.
-     * @param tenantDomain             Tenant domain.
-     * @return List of extracted EmailTemplate objects.
-     * @throws RegistryException if any error occurred.
-     */
-    private List<EmailTemplate> getAllTemplatesOfTemplateTypeFromRegistry(String templateTypeRegistryPath,
-                                                                          String tenantDomain)
-            throws RegistryException, I18nEmailMgtClientException {
-
-        List<EmailTemplate> templateList = new ArrayList<>();
-        Collection templateType = (Collection) resourceMgtService.getIdentityResource(templateTypeRegistryPath,
-                tenantDomain);
-
-        if (templateType == null) {
-            String type = templateTypeRegistryPath.split(PATH_SEPARATOR)[
-                    templateTypeRegistryPath.split(PATH_SEPARATOR).length - 1];
-            String message =
-                    String.format("Email Template Type: %s not found in %s tenant registry.", type, tenantDomain);
-            throw new I18nEmailMgtClientException(EMAIL_TEMPLATE_TYPE_NOT_FOUND, message);
-        }
-        for (String template : templateType.getChildren()) {
-            Resource templateResource = resourceMgtService.getIdentityResource(template, tenantDomain);
-            // Exclude the app templates for organization template requests.
-            if (templateResource != null && (templateTypeRegistryPath.contains(APP_TEMPLATE_PATH)
-                    || !templateResource.getPath().contains(APP_TEMPLATE_PATH))) {
-                try {
-                    EmailTemplate templateDTO = I18nEmailUtil.getEmailTemplate(templateResource);
-                    templateList.add(templateDTO);
-                } catch (I18nEmailMgtException ex) {
-                    log.error("Failed retrieving a template object from the registry resource", ex);
-                }
-            }
-        }
-        return templateList;
-    }
-
     private void handleServerException(String errorMsg, Throwable ex) throws I18nEmailMgtServerException {
 
         log.error(errorMsg);
@@ -1039,58 +731,18 @@ public class EmailTemplateManagerImpl implements EmailTemplateManager, Notificat
     }
 
     /**
-     * Add the locale to the template type resource path.
+     * Get the list of email templates from the list of notification templates.
      *
-     * @param path  Email template path
-     * @param locale Locale code of the email template
-     * @return Email template resource path
+     * @param notificationTemplates List of notification templates
+     * @return List of email templates
      */
-    private String addLocaleToTemplateTypeResourcePath(String path, String locale) {
+    private List<EmailTemplate> getEmailTemplateList(List<NotificationTemplate> notificationTemplates) {
 
-        if (StringUtils.isNotBlank(locale)) {
-            return path + PATH_SEPARATOR + locale.toLowerCase();
-        } else {
-            return path;
+        List<EmailTemplate> emailTemplates = new ArrayList<>();
+        for (NotificationTemplate notificationTemplate : notificationTemplates) {
+            EmailTemplate emailTemplate = buildEmailTemplate(notificationTemplate);
+            emailTemplates.add(emailTemplate);
         }
-    }
-
-    /**
-     * Build the template type root directory path.
-     *
-     * @param templateType          Template type
-     * @param notificationChannel   Notification channel (SMS or EMAIL)
-     * @return Root directory path
-     */
-    private String buildTemplateRootDirectoryPath(String templateType, String notificationChannel) {
-
-        return buildTemplateRootDirectoryPath(templateType, notificationChannel, null);
-    }
-
-    private String buildTemplateRootDirectoryPath(String templateType, String notificationChannel, String applicationUuid) {
-
-        if (NotificationChannels.SMS_CHANNEL.getChannelType().equals(notificationChannel)) {
-            return SMS_TEMPLATE_PATH + PATH_SEPARATOR + templateType;
-        }
-        return EMAIL_TEMPLATE_PATH + PATH_SEPARATOR + templateType + getApplicationPath(applicationUuid);
-    }
-
-    /**
-     * Build notification template model from the email template attributes.
-     *
-     * @param emailTemplate EmailTemplate
-     * @return NotificationTemplate
-     */
-    private NotificationTemplate buildNotificationTemplateFromEmailTemplate(EmailTemplate emailTemplate) {
-
-        NotificationTemplate notificationTemplate = new NotificationTemplate();
-        notificationTemplate.setNotificationChannel(NotificationChannels.EMAIL_CHANNEL.getChannelType());
-        notificationTemplate.setSubject(emailTemplate.getSubject());
-        notificationTemplate.setBody(emailTemplate.getBody());
-        notificationTemplate.setFooter(emailTemplate.getFooter());
-        notificationTemplate.setType(emailTemplate.getTemplateType());
-        notificationTemplate.setDisplayName(emailTemplate.getTemplateDisplayName());
-        notificationTemplate.setLocale(emailTemplate.getLocale());
-        notificationTemplate.setContentType(emailTemplate.getEmailContentType());
-        return notificationTemplate;
+        return emailTemplates;
     }
 }

--- a/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/dao/RegistryBasedTemplateManager.java
+++ b/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/dao/RegistryBasedTemplateManager.java
@@ -1,0 +1,561 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.email.mgt.dao;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.email.mgt.constants.I18nMgtConstants;
+import org.wso2.carbon.email.mgt.exceptions.I18nEmailMgtException;
+import org.wso2.carbon.email.mgt.internal.I18nMgtDataHolder;
+import org.wso2.carbon.email.mgt.model.EmailTemplate;
+import org.wso2.carbon.email.mgt.util.I18nEmailUtil;
+import org.wso2.carbon.identity.base.IdentityRuntimeException;
+import org.wso2.carbon.identity.core.persistence.registry.RegistryResourceMgtService;
+import org.wso2.carbon.identity.governance.IdentityMgtConstants;
+import org.wso2.carbon.identity.governance.exceptions.notiification.NotificationTemplateManagerException;
+import org.wso2.carbon.identity.governance.exceptions.notiification.NotificationTemplateManagerServerException;
+import org.wso2.carbon.identity.governance.model.NotificationTemplate;
+import org.wso2.carbon.identity.governance.service.notification.NotificationChannels;
+import org.wso2.carbon.registry.core.Collection;
+import org.wso2.carbon.registry.core.RegistryConstants;
+import org.wso2.carbon.registry.core.Resource;
+import org.wso2.carbon.registry.core.ResourceImpl;
+import org.wso2.carbon.registry.core.exceptions.RegistryException;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.wso2.carbon.email.mgt.constants.I18nMgtConstants.APP_TEMPLATE_PATH;
+import static org.wso2.carbon.email.mgt.constants.I18nMgtConstants.EMAIL_TEMPLATE_PATH;
+import static org.wso2.carbon.email.mgt.constants.I18nMgtConstants.EMAIL_TEMPLATE_TYPE_DISPLAY_NAME;
+import static org.wso2.carbon.email.mgt.constants.I18nMgtConstants.ErrorCodes.EMAIL_TEMPLATE_TYPE_NOT_FOUND;
+import static org.wso2.carbon.email.mgt.constants.I18nMgtConstants.SMS_TEMPLATE_PATH;
+import static org.wso2.carbon.registry.core.RegistryConstants.PATH_SEPARATOR;
+
+/**
+ * This class is responsible for managing the email templates in the registry.
+ */
+public class RegistryBasedTemplateManager implements TemplatePersistenceManager {
+
+    private static final Log log = LogFactory.getLog(RegistryBasedTemplateManager.class);
+
+    private I18nMgtDataHolder dataHolder = I18nMgtDataHolder.getInstance();
+    private RegistryResourceMgtService resourceMgtService = dataHolder.getRegistryResourceMgtService();
+
+    @Override
+    public void addNotificationTemplateType(String displayName, String notificationChannel, String tenantDomain)
+            throws NotificationTemplateManagerServerException {
+
+        String normalizedDisplayName = I18nEmailUtil.getNormalizedName(displayName);
+        String path = buildTemplateRootDirectoryPath(normalizedDisplayName, notificationChannel);
+
+        try {
+            // Persist the template type to registry ie. create a directory.
+            Collection collection = I18nEmailUtil.createTemplateType(normalizedDisplayName, displayName);
+            resourceMgtService.putIdentityResource(collection, path, tenantDomain);
+        } catch (IdentityRuntimeException e) {
+            throw new NotificationTemplateManagerServerException("Error while adding notification template type.", e);
+        }
+    }
+
+    @Override
+    public boolean isNotificationTemplateTypeExists(String displayName, String notificationChannel, String tenantDomain)
+            throws NotificationTemplateManagerServerException {
+
+        // get template directory name from display name.
+        String normalizedTemplateName = I18nEmailUtil.getNormalizedName(displayName);
+        String path = buildTemplateRootDirectoryPath(normalizedTemplateName, notificationChannel);
+
+        try {
+            return resourceMgtService.isResourceExists(path, tenantDomain);
+        } catch (IdentityRuntimeException e) {
+            String error = String.format("Error when retrieving email templates of %s tenant.", tenantDomain);
+            throw new NotificationTemplateManagerServerException(error, e);
+        }
+    }
+
+    @Override
+    public List<String> listNotificationTemplateTypes(String notificationChannel, String tenantDomain)
+            throws NotificationTemplateManagerServerException {
+
+        try {
+            List<String> templateTypeList = new ArrayList<>();
+            String path = buildTemplateRootDirectoryPath(notificationChannel);
+            Collection collection = (Collection) resourceMgtService.getIdentityResource(path, tenantDomain);
+
+            for (String templatePath : collection.getChildren()) {
+                Resource templateTypeResource = resourceMgtService.getIdentityResource(templatePath, tenantDomain);
+                if (templateTypeResource != null) {
+                    String emailTemplateType = templateTypeResource.getProperty(EMAIL_TEMPLATE_TYPE_DISPLAY_NAME);
+                    templateTypeList.add(emailTemplateType);
+                }
+            }
+            return templateTypeList;
+        } catch (IdentityRuntimeException | RegistryException e) {
+            throw new NotificationTemplateManagerServerException("Error while listing notification template types.", e);
+        }
+    }
+
+    @Override
+    public void deleteNotificationTemplateType(String displayName, String notificationChannel, String tenantDomain)
+            throws NotificationTemplateManagerServerException {
+
+        String templateType = I18nEmailUtil.getNormalizedName(displayName);
+        String path = buildTemplateRootDirectoryPath(templateType, notificationChannel);
+
+        try {
+            resourceMgtService.deleteIdentityResource(path, tenantDomain);
+        } catch (IdentityRuntimeException e) {
+            throw new NotificationTemplateManagerServerException("Error while deleting notification template type.", e);
+        }
+    }
+
+    @Override
+    public void addOrUpdateNotificationTemplate(NotificationTemplate notificationTemplate, String applicationUuid,
+                                                String tenantDomain) throws NotificationTemplateManagerServerException {
+
+        String notificationChannel = notificationTemplate.getNotificationChannel();
+
+        Resource templateResource = createTemplateRegistryResource(notificationTemplate);
+        String displayName = notificationTemplate.getDisplayName();
+        String type = I18nEmailUtil.getNormalizedName(displayName);
+        String locale = notificationTemplate.getLocale();
+
+        String path = buildTemplateRootDirectoryPath(type, notificationChannel, applicationUuid);
+        try {
+            // Check whether a template type root directory exists.
+            if (!resourceMgtService.isResourceExists(path, tenantDomain)) {
+                // Add new template type with relevant properties.
+                addNotificationTemplateType(displayName, notificationChannel, tenantDomain);
+                if (log.isDebugEnabled()) {
+                    String msg = "Creating template type : %s in tenant registry : %s";
+                    log.debug(String.format(msg, displayName, tenantDomain));
+                }
+            }
+            resourceMgtService.putIdentityResource(templateResource, path, tenantDomain, locale);
+        } catch (IdentityRuntimeException e) {
+            throw new NotificationTemplateManagerServerException("Error while adding notification template.", e);
+        }
+    }
+
+    @Override
+    public boolean isNotificationTemplateExists(String displayName, String locale, String notificationChannel,
+                                                String applicationUuid, String tenantDomain)
+            throws NotificationTemplateManagerServerException {
+
+        // Get template directory name from display name.
+        String normalizedTemplateName = I18nEmailUtil.getNormalizedName(displayName);
+        String path = buildTemplateRootDirectoryPath(normalizedTemplateName, notificationChannel, applicationUuid);
+        path = addLocaleToTemplateTypeResourcePath(path, locale);
+
+        try {
+            return resourceMgtService.isResourceExists(path, tenantDomain);
+        } catch (IdentityRuntimeException e) {
+            String error =
+                    String.format("Error while checking the existence of the notification template %s in %s tenant.",
+                            displayName, tenantDomain);
+            throw new NotificationTemplateManagerServerException(error, e);
+        }
+    }
+
+    @Override
+    public NotificationTemplate getNotificationTemplate(String displayName, String locale, String notificationChannel,
+                                                        String applicationUuid, String tenantDomain)
+            throws NotificationTemplateManagerServerException {
+
+        NotificationTemplate notificationTemplate = null;
+
+        String type = I18nEmailUtil.getNormalizedName(displayName);
+        String path = buildTemplateRootDirectoryPath(type, notificationChannel, applicationUuid);
+
+        // Get registry resource.
+        try {
+            Resource registryResource = resourceMgtService.getIdentityResource(path, tenantDomain, locale);
+            if (registryResource != null) {
+                notificationTemplate = getNotificationTemplate(registryResource, notificationChannel);
+            }
+        } catch (IdentityRuntimeException e) {
+            String error = String
+                    .format(IdentityMgtConstants.ErrorMessages.ERROR_CODE_ERROR_RETRIEVING_TEMPLATE_FROM_REGISTRY
+                            .getMessage(), displayName, locale, tenantDomain);
+            throw new NotificationTemplateManagerServerException(
+                    IdentityMgtConstants.ErrorMessages.ERROR_CODE_ERROR_RETRIEVING_TEMPLATE_FROM_REGISTRY.getCode(),
+                    error, e);
+        }
+
+        return notificationTemplate;
+    }
+
+    @Override
+    public List<NotificationTemplate> listNotificationTemplates(String templateDisplayName, String notificationChannel,
+                                                                String applicationUuid, String tenantDomain)
+            throws NotificationTemplateManagerServerException {
+
+        String templateDirectory = I18nEmailUtil.getNormalizedName(templateDisplayName);
+        String path = buildTemplateRootDirectoryPath(templateDirectory, notificationChannel, applicationUuid);
+
+        try {
+            return getAllTemplatesOfTemplateTypeFromRegistry(path, tenantDomain);
+        } catch (RegistryException e) {
+            String error = "Error when retrieving '%s' template type from %s tenant registry.";
+            throw new NotificationTemplateManagerServerException(
+                    String.format(error, templateDisplayName, tenantDomain), e);
+        }
+    }
+
+    @Override
+    public List<NotificationTemplate> listAllNotificationTemplates(String notificationChannel, String tenantDomain)
+            throws NotificationTemplateManagerServerException {
+
+        List<NotificationTemplate> templateList = new ArrayList<>();
+
+        try {
+            String path = buildTemplateRootDirectoryPath(notificationChannel);
+            Collection baseDirectory = (Collection) resourceMgtService.getIdentityResource(path, tenantDomain);
+
+            if (baseDirectory != null) {
+                for (String templateTypeDirectory : baseDirectory.getChildren()) {
+                    templateList.addAll(
+                            getAllTemplatesOfTemplateTypeFromRegistry(templateTypeDirectory, tenantDomain));
+                }
+            }
+        } catch (RegistryException | IdentityRuntimeException e) {
+            throw new NotificationTemplateManagerServerException("Error while listing all notification templates.", e);
+        }
+
+        return templateList;
+    }
+
+    @Override
+    public void deleteNotificationTemplate(String displayName, String locale, String notificationChannel,
+                                           String applicationUuid, String tenantDomain)
+            throws NotificationTemplateManagerServerException {
+
+        String templateType = I18nEmailUtil.getNormalizedName(displayName);
+        String path = buildTemplateRootDirectoryPath(templateType, notificationChannel, applicationUuid);
+        try {
+            resourceMgtService.deleteIdentityResource(path, tenantDomain, locale);
+        } catch (IdentityRuntimeException e) {
+            String msg = String.format("Error deleting %s:%s template from %s tenant registry.", displayName,
+                    locale, tenantDomain);
+            throw new NotificationTemplateManagerServerException(msg, e);
+        }
+    }
+
+    @Override
+    public void deleteNotificationTemplates(String displayName, String notificationChannel, String applicationUuid,
+                                            String tenantDomain) throws NotificationTemplateManagerServerException {
+
+        String templateType = I18nEmailUtil.getNormalizedName(displayName);
+        String path = buildTemplateRootDirectoryPath(templateType, notificationChannel, applicationUuid);
+
+        try {
+            if (StringUtils.isBlank(applicationUuid)) {
+                // Delete org templates
+                Collection templates = (Collection) resourceMgtService.getIdentityResource(path, tenantDomain);
+                for (String subPath : templates.getChildren()) {
+                    // Exclude the app templates.
+                    if (!subPath.contains(APP_TEMPLATE_PATH)) {
+                        resourceMgtService.deleteIdentityResource(subPath, tenantDomain);
+                    }
+                }
+            } else {
+                // Delete app templates
+                if (!resourceMgtService.isResourceExists(path, tenantDomain)) {
+                    // No templates found for the given application UUID.
+                    return;
+                }
+                resourceMgtService.deleteIdentityResource(path, tenantDomain);
+            }
+        } catch (IdentityRuntimeException | RegistryException e) {
+            throw new NotificationTemplateManagerServerException("Error while deleting notification templates.", e);
+        }
+    }
+
+    /**
+     * Get the notification template from resource.
+     *
+     * @param templateResource    {@link org.wso2.carbon.registry.core.Resource} object
+     * @param notificationChannel Notification channel
+     * @return {@link org.wso2.carbon.identity.governance.model.NotificationTemplate} object
+     * @throws NotificationTemplateManagerException Error getting the notification template
+     */
+    private NotificationTemplate getNotificationTemplate(Resource templateResource, String notificationChannel)
+            throws NotificationTemplateManagerServerException {
+
+        NotificationTemplate notificationTemplate = new NotificationTemplate();
+
+        // Get template meta properties.
+        String displayName = templateResource.getProperty(I18nMgtConstants.TEMPLATE_TYPE_DISPLAY_NAME);
+        String type = templateResource.getProperty(I18nMgtConstants.TEMPLATE_TYPE);
+        String locale = templateResource.getProperty(I18nMgtConstants.TEMPLATE_LOCALE);
+        if (NotificationChannels.EMAIL_CHANNEL.getChannelType().equals(notificationChannel)) {
+            String contentType = templateResource.getProperty(I18nMgtConstants.TEMPLATE_CONTENT_TYPE);
+
+            // Setting UTF-8 for all the email templates as it supports many languages and is widely adopted.
+            // There is little to no value addition making the charset configurable.
+            if (contentType != null && !contentType.toLowerCase().contains(I18nEmailUtil.CHARSET_CONSTANT)) {
+                contentType = contentType + "; " + I18nEmailUtil.CHARSET_UTF_8;
+            }
+            notificationTemplate.setContentType(contentType);
+        }
+        notificationTemplate.setDisplayName(displayName);
+        notificationTemplate.setType(type);
+        notificationTemplate.setLocale(locale);
+
+        // Process template content.
+        String[] templateContentElements = getTemplateElements(templateResource, notificationChannel, displayName,
+                locale);
+        if (NotificationChannels.SMS_CHANNEL.getChannelType().equals(notificationChannel)) {
+            notificationTemplate.setBody(templateContentElements[0]);
+        } else {
+            notificationTemplate.setSubject(templateContentElements[0]);
+            notificationTemplate.setBody(templateContentElements[1]);
+            notificationTemplate.setFooter(templateContentElements[2]);
+        }
+        notificationTemplate.setNotificationChannel(notificationChannel);
+        return notificationTemplate;
+    }
+
+    /**
+     * Process template resource content and retrieve template elements.
+     *
+     * @param templateResource    Resource of the template
+     * @param notificationChannel Notification channel
+     * @param displayName         Display name of the template
+     * @param locale              Locale of the template
+     * @return Template content
+     * @throws NotificationTemplateManagerServerException If an error occurred while getting the template content
+     */
+    private String[] getTemplateElements(Resource templateResource, String notificationChannel, String displayName,
+                                         String locale) throws NotificationTemplateManagerServerException {
+
+        try {
+            Object content = templateResource.getContent();
+            if (content != null) {
+                byte[] templateContentArray = (byte[]) content;
+                String templateContent = new String(templateContentArray, Charset.forName("UTF-8"));
+
+                String[] templateContentElements;
+                try {
+                    templateContentElements = new Gson().fromJson(templateContent, String[].class);
+                } catch (JsonSyntaxException exception) {
+                    String error = String.format(IdentityMgtConstants.ErrorMessages.
+                            ERROR_CODE_DESERIALIZING_TEMPLATE_FROM_TENANT_REGISTRY.getMessage(), displayName, locale);
+                    throw new NotificationTemplateManagerServerException(IdentityMgtConstants.ErrorMessages.
+                            ERROR_CODE_DESERIALIZING_TEMPLATE_FROM_TENANT_REGISTRY.getCode(), error, exception);
+                }
+
+                // Validate template content.
+                if (NotificationChannels.SMS_CHANNEL.getChannelType().equals(notificationChannel)) {
+                    if (templateContentElements == null || templateContentElements.length != 1) {
+                        String errorMsg = String.format(IdentityMgtConstants.ErrorMessages.
+                                ERROR_CODE_INVALID_SMS_TEMPLATE_CONTENT.getMessage(), displayName, locale);
+                        throw new NotificationTemplateManagerServerException(IdentityMgtConstants.ErrorMessages.
+                                ERROR_CODE_INVALID_SMS_TEMPLATE_CONTENT.getCode(), errorMsg);
+                    }
+                } else {
+                    if (templateContentElements == null || templateContentElements.length != 3) {
+                        String errorMsg = String.format(IdentityMgtConstants.ErrorMessages.
+                                ERROR_CODE_INVALID_EMAIL_TEMPLATE_CONTENT.getMessage(), displayName, locale);
+                        throw new NotificationTemplateManagerServerException(IdentityMgtConstants.ErrorMessages.
+                                ERROR_CODE_INVALID_EMAIL_TEMPLATE_CONTENT.getCode(), errorMsg);
+                    }
+                }
+                return templateContentElements;
+            } else {
+                String error = String.format(IdentityMgtConstants.ErrorMessages.
+                        ERROR_CODE_NO_CONTENT_IN_TEMPLATE.getMessage(), displayName, locale);
+                throw new NotificationTemplateManagerServerException(IdentityMgtConstants.ErrorMessages.
+                        ERROR_CODE_NO_CONTENT_IN_TEMPLATE.getCode(), error);
+            }
+        } catch (RegistryException exception) {
+            String error = IdentityMgtConstants.ErrorMessages.
+                    ERROR_CODE_ERROR_RETRIEVING_TEMPLATE_OBJECT_FROM_REGISTRY.getMessage();
+            throw new NotificationTemplateManagerServerException(IdentityMgtConstants.ErrorMessages.
+                    ERROR_CODE_ERROR_RETRIEVING_TEMPLATE_OBJECT_FROM_REGISTRY.getCode(), error, exception);
+        }
+    }
+
+    /**
+     * Create a registry resource instance of the notification template.
+     *
+     * @param notificationTemplate Notification template
+     * @return Resource
+     * @throws NotificationTemplateManagerServerException If an error occurred while creating the resource
+     */
+    private Resource createTemplateRegistryResource(NotificationTemplate notificationTemplate)
+            throws NotificationTemplateManagerServerException {
+
+        String displayName = notificationTemplate.getDisplayName();
+        String type = I18nEmailUtil.getNormalizedName(displayName);
+        String locale = notificationTemplate.getLocale();
+        String body = notificationTemplate.getBody();
+
+        // Set template properties.
+        Resource templateResource = new ResourceImpl();
+        templateResource.setProperty(I18nMgtConstants.TEMPLATE_TYPE_DISPLAY_NAME, displayName);
+        templateResource.setProperty(I18nMgtConstants.TEMPLATE_TYPE, type);
+        templateResource.setProperty(I18nMgtConstants.TEMPLATE_LOCALE, locale);
+        String[] templateContent;
+        // Handle contents according to different channel types.
+        if (NotificationChannels.EMAIL_CHANNEL.getChannelType().equals(notificationTemplate.getNotificationChannel())) {
+            templateContent = new String[]{notificationTemplate.getSubject(), body, notificationTemplate.getFooter()};
+            templateResource.setProperty(I18nMgtConstants.TEMPLATE_CONTENT_TYPE, notificationTemplate.getContentType());
+        } else {
+            templateContent = new String[]{body};
+        }
+        templateResource.setMediaType(RegistryConstants.TAG_MEDIA_TYPE);
+        String content = new Gson().toJson(templateContent);
+        try {
+            byte[] contentByteArray = content.getBytes(StandardCharsets.UTF_8);
+            templateResource.setContent(contentByteArray);
+        } catch (RegistryException e) {
+            String code =
+                    I18nEmailUtil.prependOperationScenarioToErrorCode(
+                            I18nMgtConstants.ErrorMessages.ERROR_CODE_ERROR_CREATING_REGISTRY_RESOURCE.getCode(),
+                            I18nMgtConstants.ErrorScenarios.EMAIL_TEMPLATE_MANAGER);
+            String message =
+                    String.format(
+                            I18nMgtConstants.ErrorMessages.ERROR_CODE_ERROR_CREATING_REGISTRY_RESOURCE.getMessage(),
+                            displayName, locale);
+            throw new NotificationTemplateManagerServerException(code, message, e);
+        }
+        return templateResource;
+    }
+
+    /**
+     * Build application template path from application UUID or return empty string if application UUID is null.
+     *
+     * @param applicationUuid Application UUID.
+     * @return Application template path.
+     */
+    private String getApplicationPath(String applicationUuid) {
+
+        if (StringUtils.isNotBlank(applicationUuid)) {
+            return APP_TEMPLATE_PATH + PATH_SEPARATOR + applicationUuid;
+        }
+        return StringUtils.EMPTY;
+    }
+
+    /**
+     * Loop through all template resources of a given template type registry path and return a list of EmailTemplate
+     * objects.
+     *
+     * @param templateTypeRegistryPath Registry path of the template type.
+     * @param tenantDomain             Tenant domain.
+     * @return List of extracted EmailTemplate objects.
+     * @throws RegistryException if any error occurred.
+     */
+    private List<NotificationTemplate> getAllTemplatesOfTemplateTypeFromRegistry(String templateTypeRegistryPath,
+                                                                                 String tenantDomain)
+            throws NotificationTemplateManagerServerException, RegistryException {
+
+        List<NotificationTemplate> templateList = new ArrayList<>();
+        Collection templateType = (Collection) resourceMgtService.getIdentityResource(templateTypeRegistryPath,
+                tenantDomain);
+
+        if (templateType == null) {
+            String type = templateTypeRegistryPath.split(PATH_SEPARATOR)[
+                    templateTypeRegistryPath.split(PATH_SEPARATOR).length - 1];
+            String message =
+                    String.format("Notification Template Type: %s not found in %s tenant registry.", type,
+                            tenantDomain);
+            throw new NotificationTemplateManagerServerException(EMAIL_TEMPLATE_TYPE_NOT_FOUND, message);
+        }
+        for (String template : templateType.getChildren()) {
+            Resource templateResource = resourceMgtService.getIdentityResource(template, tenantDomain);
+            // Exclude the app templates for organization template requests.
+            if (templateResource != null && (templateTypeRegistryPath.contains(APP_TEMPLATE_PATH)
+                    || !templateResource.getPath().contains(APP_TEMPLATE_PATH))) {
+                try {
+                    EmailTemplate templateDTO = I18nEmailUtil.getEmailTemplate(templateResource);
+                    templateList.add(I18nEmailUtil.buildNotificationTemplateFromEmailTemplate(templateDTO));
+                } catch (I18nEmailMgtException e) {
+                    log.error("Failed retrieving a template object from the registry resource", e);
+                }
+            }
+        }
+        return templateList;
+    }
+
+    /**
+     * Add the locale to the template type resource path.
+     *
+     * @param path   Email template path
+     * @param locale Locale code of the email template
+     * @return Email template resource path
+     */
+    private String addLocaleToTemplateTypeResourcePath(String path, String locale) {
+
+        if (StringUtils.isNotBlank(locale)) {
+            return path + PATH_SEPARATOR + locale.toLowerCase();
+        } else {
+            return path;
+        }
+    }
+
+    /**
+     * Build the template type root directory path.
+     *
+     * @param templateType        Template type
+     * @param notificationChannel Notification channel (SMS or EMAIL)
+     * @return Root directory path
+     */
+    private String buildTemplateRootDirectoryPath(String templateType, String notificationChannel) {
+
+        return buildTemplateRootDirectoryPath(templateType, notificationChannel, null);
+    }
+
+    /**
+     * Build the template root directory path.
+     *
+     * @param templateType          Template type
+     * @param notificationChannel   Notification channel
+     * @param applicationUuid       Application UUID
+     * @return Root directory path
+     */
+    private String buildTemplateRootDirectoryPath(String templateType, String notificationChannel,
+                                                  String applicationUuid) {
+
+        if (NotificationChannels.SMS_CHANNEL.getChannelType().equals(notificationChannel)) {
+            return SMS_TEMPLATE_PATH + PATH_SEPARATOR + templateType;
+        }
+        return EMAIL_TEMPLATE_PATH + PATH_SEPARATOR + templateType + getApplicationPath(applicationUuid);
+    }
+
+    /**
+     * Build the template root directory path.
+     *
+     * @param notificationChannel   Notification channel
+     * @return Root directory path
+     */
+    private String buildTemplateRootDirectoryPath(String notificationChannel) {
+
+        if (NotificationChannels.SMS_CHANNEL.getChannelType().equals(notificationChannel)) {
+            return SMS_TEMPLATE_PATH;
+        }
+        return EMAIL_TEMPLATE_PATH;
+    }
+}

--- a/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/dao/TemplatePersistenceManager.java
+++ b/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/dao/TemplatePersistenceManager.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.email.mgt.dao;
+
+import org.wso2.carbon.identity.governance.exceptions.notiification.NotificationTemplateManagerServerException;
+import org.wso2.carbon.identity.governance.model.NotificationTemplate;
+
+import java.util.List;
+
+/**
+ * This interface is used to manage the persistence of notification templates.
+ */
+public interface TemplatePersistenceManager {
+
+    /**
+     * Add a notification template type.
+     *
+     * @param displayName           Display name of the template type.
+     * @param notificationChannel   Notification channel.
+     * @param tenantDomain          Tenant domain.
+     * @throws NotificationTemplateManagerServerException If an error occurred while adding the template type.
+     */
+    void addNotificationTemplateType(String displayName, String notificationChannel, String tenantDomain)
+            throws NotificationTemplateManagerServerException;
+
+    /**
+     * Check whether the specified notification template type exists.
+     *
+     * @param displayName           Display name of the template type.
+     * @param notificationChannel   Notification channel.
+     * @param tenantDomain          Tenant domain.
+     * @return True if the template type exists, false otherwise.
+     * @throws NotificationTemplateManagerServerException If an error occurred while checking the existence.
+     */
+    boolean isNotificationTemplateTypeExists(String displayName, String notificationChannel, String tenantDomain)
+            throws NotificationTemplateManagerServerException;
+
+    /**
+     * Get all notification template types for given channel and tenant.
+     *
+     * @param notificationChannel   Notification channel.
+     * @param tenantDomain          Tenant domain.
+     * @return                      List of available template types.
+     * @throws NotificationTemplateManagerServerException If an error occurred while retrieving the template types.
+     */
+    List<String> listNotificationTemplateTypes(String notificationChannel, String tenantDomain)
+            throws NotificationTemplateManagerServerException;
+
+    /**
+     * Delete specified notification template type.
+     *
+     * @param displayName           Display name of the template type.
+     * @param notificationChannel   Notification channel.
+     * @param tenantDomain          Tenant domain.
+     * @throws NotificationTemplateManagerServerException If an error occurred while deleting the template type.
+     */
+    void deleteNotificationTemplateType(String displayName, String notificationChannel, String tenantDomain)
+            throws NotificationTemplateManagerServerException;
+
+    /**
+     * Update the notification template if exists or add a new template if not exists.
+     *
+     * @param notificationTemplate  Notification template.
+     * @param applicationUuid       Application UUID.
+     * @param tenantDomain          Tenant domain.
+     * @throws NotificationTemplateManagerServerException If an error occurred while adding or updating the template.
+     */
+    void addOrUpdateNotificationTemplate(NotificationTemplate notificationTemplate, String applicationUuid,
+                                         String tenantDomain) throws NotificationTemplateManagerServerException;
+
+    /**
+     * Check whether the specified notification template exists.
+     *
+     * @param displayName           Display Name.
+     * @param locale                Locale of the template.
+     * @param notificationChannel   Notification channel.
+     * @param applicationUuid       Application UUID.
+     * @param tenantDomain          Tenant domain.
+     * @return True if the template exists, false otherwise.
+     * @throws NotificationTemplateManagerServerException If an error occurred while checking the existence.
+     */
+    boolean isNotificationTemplateExists(String displayName, String locale, String notificationChannel,
+                                         String applicationUuid, String tenantDomain)
+            throws NotificationTemplateManagerServerException;
+
+    /**
+     * Get specified notification template.
+     *
+     * @param displayName           Display Name.
+     * @param locale                Locale of the template.
+     * @param notificationChannel   Notification channel.
+     * @param applicationUuid       Application UUID.
+     * @param tenantDomain          Tenant domain.
+     * @return Notification template.
+     * @throws NotificationTemplateManagerServerException If an error occurred while retrieving the template.
+     */
+    NotificationTemplate getNotificationTemplate(String displayName, String locale, String notificationChannel,
+                                                 String applicationUuid, String tenantDomain)
+            throws NotificationTemplateManagerServerException;
+
+    /**
+     * Get the list of notification templates for given template type, channel, application and tenant.
+     *
+     * @param templateType          Template type.
+     * @param notificationChannel   Notification channel.
+     * @param applicationUuid       Application UUID.
+     * @param tenantDomain          Tenant domain.
+     * @return List of available notification templates.
+     * @throws NotificationTemplateManagerServerException If an error occurred while retrieving the templates.
+     */
+    List<NotificationTemplate> listNotificationTemplates(String templateType, String notificationChannel,
+                                                         String applicationUuid, String tenantDomain)
+            throws NotificationTemplateManagerServerException;
+
+    /**
+     * Get all notification templates for given channel and tenant.
+     *
+     * @param notificationChannel   Notification channel.
+     * @param tenantDomain          Tenant domain.
+     * @return List of available notification templates.
+     * @throws NotificationTemplateManagerServerException If an error occurred while retrieving the templates.
+     */
+    List<NotificationTemplate> listAllNotificationTemplates(String notificationChannel, String tenantDomain)
+            throws NotificationTemplateManagerServerException;
+
+    /**
+     * Delete specified notification template.
+     *
+     * @param displayName           Display Name.
+     * @param locale                Locale of the template.
+     * @param notificationChannel   Notification channel.
+     * @param applicationUuid       Application UUID.
+     * @param tenantDomain          Tenant domain.
+     * @throws NotificationTemplateManagerServerException If an error occurred while deleting the template.
+     */
+    void deleteNotificationTemplate(String displayName, String locale, String notificationChannel,
+                                    String applicationUuid, String tenantDomain)
+            throws NotificationTemplateManagerServerException;
+
+    /**
+     * Delete all notification templates for given template type, channel, application and tenant.
+     *
+     * @param displayName           Display Name.
+     * @param notificationChannel   Notification channel.
+     * @param applicationUuid       Application UUID.
+     * @param tenantDomain          Tenant domain.
+     * @throws NotificationTemplateManagerServerException If an error occurred while deleting the templates.
+     */
+    void deleteNotificationTemplates(String displayName, String notificationChannel, String applicationUuid,
+                                     String tenantDomain) throws NotificationTemplateManagerServerException;
+}

--- a/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/util/I18nEmailUtil.java
+++ b/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/util/I18nEmailUtil.java
@@ -28,6 +28,7 @@ import org.wso2.carbon.email.mgt.exceptions.I18nMgtEmailConfigException;
 import org.wso2.carbon.email.mgt.internal.I18nMgtDataHolder;
 import org.wso2.carbon.email.mgt.model.EmailTemplate;
 import org.wso2.carbon.identity.governance.model.NotificationTemplate;
+import org.wso2.carbon.identity.governance.service.notification.NotificationChannels;
 import org.wso2.carbon.registry.core.Collection;
 import org.wso2.carbon.registry.core.CollectionImpl;
 import org.wso2.carbon.registry.core.RegistryConstants;
@@ -97,6 +98,26 @@ public class I18nEmailUtil {
         emailTemplate.setFooter(notificationTemplate.getFooter());
         emailTemplate.setEmailContentType(notificationTemplate.getContentType());
         return emailTemplate;
+    }
+
+    /**
+     * Build notification template model from the email template attributes.
+     *
+     * @param emailTemplate EmailTemplate
+     * @return NotificationTemplate
+     */
+    public static NotificationTemplate buildNotificationTemplateFromEmailTemplate(EmailTemplate emailTemplate) {
+
+        NotificationTemplate notificationTemplate = new NotificationTemplate();
+        notificationTemplate.setNotificationChannel(NotificationChannels.EMAIL_CHANNEL.getChannelType());
+        notificationTemplate.setSubject(emailTemplate.getSubject());
+        notificationTemplate.setBody(emailTemplate.getBody());
+        notificationTemplate.setFooter(emailTemplate.getFooter());
+        notificationTemplate.setType(emailTemplate.getTemplateType());
+        notificationTemplate.setDisplayName(emailTemplate.getTemplateDisplayName());
+        notificationTemplate.setLocale(emailTemplate.getLocale());
+        notificationTemplate.setContentType(emailTemplate.getEmailContentType());
+        return notificationTemplate;
     }
 
     /**


### PR DESCRIPTION
### Proposed changes in this pull request

`EmailTemplateManagerImpl` currently have its business logic and storage logic mixed up. This PR separate out those two layers and give the flexibility plug different type of storage implementations without having to modifying/duplicating the business logic.

### When should this PR be merged

Immediate

### Follow up actions

N/A