### PR TITLE
Fix code coverage analysis

### DIFF
--- a/components/email-mgt/org.wso2.carbon.email.mgt/pom.xml
+++ b/components/email-mgt/org.wso2.carbon.email.mgt/pom.xml
@@ -157,7 +157,9 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven.surefire.plugin.version}</version>
                 <configuration>
+                    <!--suppress UnresolvedMavenProperty -->
                     <argLine>
+                        ${argLine}
                         --add-opens java.xml/jdk.xml.internal=ALL-UNNAMED
                         --add-opens=java.base/jdk.internal.loader=ALL-UNNAMED
                     </argLine>


### PR DESCRIPTION
### Proposed changes in this pull request

Running the code coverage analysis with jacoco plugin has been skipped since https://github.com/wso2-extensions/identity-event-handler-notification/pull/226 due to introduction of `argLine` for the surefire plugin.

This is a known case[1] and fixed with this.

[1] https://mjremijan.blogspot.com/2017/01/jacoco-surefire-argline-why-jacocoexe.html

### When should this PR be merged

Immediate.


### Follow up actions

N/A