### PR TITLE
Fix user claims not being available for federated users

### DIFF
--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/NotificationConstants.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/NotificationConstants.java
@@ -32,6 +32,9 @@ public class NotificationConstants {
     public static final String DEFAULT_NOTIFICATION_LOCALE = "en_US";
     public static final String NOTIFICATION_DEFAULT_LOCALE = "Notification.DefaultLocale";
     public static final String TENANT_DOMAIN = "tenant-domain";
+    public static final String IS_FEDERATED_USER = "isFederatedUser";
+    public static final String FEDERATED_USER_CLAIMS = "federatedUserClaims";
+
 
     public static class EmailNotification {
         public static final String EMAIL_TEMPLATE_PATH = "identity/Email/";

--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/util/NotificationUtil.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/util/NotificationUtil.java
@@ -653,7 +653,8 @@ public class NotificationUtil {
         String appDomain = (String) event.getEventProperties().get(IdentityEventConstants.EventProperty.APPLICATION_DOMAIN);
 
         // If the user is federated, use the federated user claims provided in the event properties.
-        if ((Boolean) event.getEventProperties().get(NotificationConstants.IS_FEDERATED_USER) &&
+        if (event.getEventProperties().containsKey(NotificationConstants.IS_FEDERATED_USER) &&
+                (Boolean) event.getEventProperties().get(NotificationConstants.IS_FEDERATED_USER) &&
                 event.getEventProperties().containsKey(NotificationConstants.FEDERATED_USER_CLAIMS)) {
             Map<String, String> fedUserClaims = new HashMap<>();
             ((Map<ClaimMapping, String>) event.getEventProperties().get(NotificationConstants.FEDERATED_USER_CLAIMS))

--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/util/NotificationUtil.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/util/NotificationUtil.java
@@ -35,6 +35,7 @@ import org.wso2.carbon.event.stream.core.EventStreamService;
 import org.wso2.carbon.event.stream.core.exception.EventStreamConfigurationException;
 import org.wso2.carbon.identity.application.authentication.framework.config.ConfigurationFacade;
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
+import org.wso2.carbon.identity.application.common.model.ClaimMapping;
 import org.wso2.carbon.identity.branding.preference.management.core.BrandingPreferenceManager;
 import org.wso2.carbon.identity.branding.preference.management.core.BrandingPreferenceManagerImpl;
 import org.wso2.carbon.identity.branding.preference.management.core.constant.BrandingPreferenceMgtConstants;
@@ -651,11 +652,21 @@ public class NotificationUtil {
         String sendFrom = (String) event.getEventProperties().get(NotificationConstants.EmailNotification.ARBITRARY_SEND_FROM);
         String appDomain = (String) event.getEventProperties().get(IdentityEventConstants.EventProperty.APPLICATION_DOMAIN);
 
-        if (StringUtils.isNotBlank(username) && userStoreManager != null) {
-            userClaims = NotificationUtil.getUserClaimValues(username, userStoreManager);
-        } else if (StringUtils.isNotBlank(username) && StringUtils.isNotBlank(userStoreDomainName) &&
-                StringUtils.isNotBlank(tenantDomain)) {
-            userClaims = NotificationUtil.getUserClaimValues(username, userStoreDomainName, tenantDomain);
+        // If the user is federated, use the federated user claims provided in the event properties.
+        if ((Boolean) event.getEventProperties().get(NotificationConstants.IS_FEDERATED_USER) &&
+                event.getEventProperties().containsKey(NotificationConstants.FEDERATED_USER_CLAIMS)) {
+            Map<String, String> fedUserClaims = new HashMap<>();
+            ((Map<ClaimMapping, String>) event.getEventProperties().get(NotificationConstants.FEDERATED_USER_CLAIMS))
+                    .forEach((claimMapping, value) ->
+                            fedUserClaims.put(claimMapping.getLocalClaim().getClaimUri(), value));
+            userClaims.putAll(fedUserClaims);
+        } else {
+            if (StringUtils.isNotBlank(username) && userStoreManager != null) {
+                userClaims = NotificationUtil.getUserClaimValues(username, userStoreManager);
+            } else if (StringUtils.isNotBlank(username) && StringUtils.isNotBlank(userStoreDomainName) &&
+                    StringUtils.isNotBlank(tenantDomain)) {
+                userClaims = NotificationUtil.getUserClaimValues(username, userStoreDomainName, tenantDomain);
+            }
         }
 
         String locale = getNotificationLocale();


### PR DESCRIPTION
### Proposed changes in this pull request

For federated users, user claims will not be available since from the authenticator the authenticated user is passed in the event properties instead of the locally mapped user. Therefore, with this change for the federated users, from the authenticator user claims will be added to the event properties and will be consumed here if the user is federated.

### Related PRs

https://github.com/wso2-extensions/identity-local-auth-emailotp/pull/32