### PR TITLE
Handle email template not found

### DIFF
--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/NotificationConstants.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/NotificationConstants.java
@@ -34,7 +34,7 @@ public class NotificationConstants {
     public static final String TENANT_DOMAIN = "tenant-domain";
     public static final String IS_FEDERATED_USER = "isFederatedUser";
     public static final String FEDERATED_USER_CLAIMS = "federatedUserClaims";
-
+    public static final String IGNORE_IF_TEMPLATE_NOT_FOUND = "ignoreIfTemplateNotFound";
 
     public static class EmailNotification {
         public static final String EMAIL_TEMPLATE_PATH = "identity/Email/";

--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/NotificationHandler.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/NotificationHandler.java
@@ -94,6 +94,14 @@ public class NotificationHandler extends DefaultNotificationHandler {
 
         Notification notification = NotificationUtil.buildNotification(event, arbitraryDataMap);
 
+        if (notification == null) {
+            if (log.isDebugEnabled()) {
+                log.debug("Notification is null. Hence returning without sending the notification." +
+                        " Event : " + event.getEventName());
+            }
+            return;
+        }
+
         //Stream definition will be read from the identity-even.properties file as a property of the subscription
         //property. Then it will get the first priority.
         String streamDefinitionID = getStreamDefinitionID(event);


### PR DESCRIPTION
### Proposed changes in this pull request

Introduce an event property to ignore throwing an error if the email template is not found. This is introduced to handle the backward compatibility. 