### PR TITLE
Check OIDC Dialect Email Claim URI, If `sendTo` is Empty

### DIFF
--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/NotificationConstants.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/NotificationConstants.java
@@ -1,17 +1,17 @@
 /*
- * Copyright (c) 2016, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2016-2024, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the
+ * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
  */
@@ -43,6 +43,7 @@ public class NotificationConstants {
         public static final String TEMPLATE_CONTENT_TYPE_DEFAULT = "text/plain";
         public static final String CLAIM_URI_LOCALE = IdentityUtil.getClaimUriLocale();
         public static final String CLAIM_URI_EMAIL = "http://wso2.org/claims/emailaddress";
+        public static final String OIDC_CLAIM_URI_EMAIL = "email";
         public static final String IDENTITY_CLAIM_PREFIX = "identity";
         public static final String USER_CLAIM_PREFIX = "user.claim";
         public static final String IDENTITY_TEMPLATE_VALUE_PREFIX = "server.placeholder";

--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/util/NotificationUtil.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/util/NotificationUtil.java
@@ -680,6 +680,12 @@ public class NotificationUtil {
             if (userClaims.containsKey(NotificationConstants.EmailNotification.CLAIM_URI_EMAIL)) {
                 sendTo = userClaims.get(NotificationConstants.EmailNotification.CLAIM_URI_EMAIL);
             }
+            // If OIDC dialect is used, claim URI for user email address will be "email".
+            // Hence, if sendTo is still empty, check whether "email" claim is available.
+            if (StringUtils.isEmpty(sendTo) &&
+                    userClaims.containsKey(NotificationConstants.EmailNotification.OIDC_CLAIM_URI_EMAIL)) {
+                sendTo = userClaims.get(NotificationConstants.EmailNotification.OIDC_CLAIM_URI_EMAIL);
+            }
             if (StringUtils.isEmpty(sendTo)) {
                 throw new IdentityEventException("Email notification sending failed. " +
                         "Sending email address is not configured for the user.");


### PR DESCRIPTION
### Proposed changes in this pull request

- When OIDC dialect is used (this is used by OIDC IdPs like Google), the email claim URI will be in the format of `email`, which is not checked when configuring `sendTo` variable while building the email notification.
- Therefore, with this PR, OIDC dialect email claim URI will be checked if the `sedTo` variable is still empty.
