### PR TITLE
Fix Cache Keys in Org/App Template Caches and Refactor NotificationTypeCacheKey

### DIFF
--- a/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/cache/AppNotificationTemplateCacheKey.java
+++ b/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/cache/AppNotificationTemplateCacheKey.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.email.mgt.cache;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 /**
  * This class represent cache key for {@link AppNotificationTemplateCache}.
@@ -36,5 +37,23 @@ public class AppNotificationTemplateCacheKey implements Serializable {
         this.templateType = templateType;
         this.channelName = channelName;
         this.applicationUuid = applicationUuid;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AppNotificationTemplateCacheKey cacheKey = (AppNotificationTemplateCacheKey) o;
+        return Objects.equals(locale, cacheKey.locale) &&
+                Objects.equals(templateType, cacheKey.templateType) &&
+                Objects.equals(channelName, cacheKey.channelName) &&
+                Objects.equals(applicationUuid, cacheKey.applicationUuid);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(locale, templateType, channelName, applicationUuid);
     }
 }

--- a/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/cache/AppNotificationTemplateListCacheKey.java
+++ b/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/cache/AppNotificationTemplateListCacheKey.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.email.mgt.cache;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 /**
  * This class represent cache key for {@link AppNotificationTemplateListCache}.
@@ -33,5 +34,22 @@ public class AppNotificationTemplateListCacheKey implements Serializable {
         this.templateType = templateType;
         this.channelName = channelName;
         this.applicationUuid = applicationUuid;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AppNotificationTemplateListCacheKey that = (AppNotificationTemplateListCacheKey) o;
+        return Objects.equals(templateType, that.templateType) &&
+                Objects.equals(channelName, that.channelName) &&
+                Objects.equals(applicationUuid, that.applicationUuid);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(templateType, channelName, applicationUuid);
     }
 }

--- a/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/cache/NotificationTypeCacheKey.java
+++ b/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/cache/NotificationTypeCacheKey.java
@@ -37,39 +37,19 @@ public class NotificationTypeCacheKey implements Serializable {
         this.channelName = channelName;
     }
 
-    public String getNotificationType() {
-
-        return notificationType;
-    }
-
-    public String getChannelName() {
-
-        return channelName;
-    }
-
     @Override
     public boolean equals(Object o) {
 
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
         NotificationTypeCacheKey that = (NotificationTypeCacheKey) o;
-
-        if (!Objects.equals(notificationType, that.notificationType)) {
-            return false;
-        }
-        return Objects.equals(channelName, that.channelName);
+        return Objects.equals(notificationType, that.notificationType) &&
+                Objects.equals(channelName, that.channelName);
     }
 
     @Override
     public int hashCode() {
 
-        int result = notificationType != null ? notificationType.hashCode() : 0;
-        result = 31 * result + (channelName != null ? channelName.hashCode() : 0);
-        return result;
+        return Objects.hash(notificationType, channelName);
     }
 }

--- a/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/cache/OrgNotificationTemplateCacheKey.java
+++ b/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/cache/OrgNotificationTemplateCacheKey.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.email.mgt.cache;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 /**
  * This class represent cache key for {@link OrgNotificationTemplateCache}.
@@ -33,5 +34,21 @@ public class OrgNotificationTemplateCacheKey implements Serializable {
         this.locale = locale;
         this.templateType = templateType;
         this.channelName = channelName;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        OrgNotificationTemplateCacheKey key = (OrgNotificationTemplateCacheKey) o;
+        return Objects.equals(locale, key.locale) && Objects.equals(templateType, key.templateType) &&
+                Objects.equals(channelName, key.channelName);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(locale, templateType, channelName);
     }
 }

--- a/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/cache/OrgNotificationTemplateListCacheKey.java
+++ b/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/cache/OrgNotificationTemplateListCacheKey.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.email.mgt.cache;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 /**
  * This class represent cache key for {@link OrgNotificationTemplateListCache}.
@@ -31,5 +32,21 @@ public class OrgNotificationTemplateListCacheKey implements Serializable {
     public OrgNotificationTemplateListCacheKey(String templateType, String channelName) {
         this.templateType = templateType;
         this.channelName = channelName;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        OrgNotificationTemplateListCacheKey that = (OrgNotificationTemplateListCacheKey) o;
+        return Objects.equals(templateType, that.templateType) &&
+                Objects.equals(channelName, that.channelName);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(templateType, channelName);
     }
 }


### PR DESCRIPTION
### Proposed changes in this pull request

$subject.. Improves https://github.com/wso2-extensions/identity-event-handler-notification/pull/244

Only the NotificationTypeCache works as expected with the https://github.com/wso2-extensions/identity-event-handler-notification/pull/244 since its the only cache properly implemented `equals()` in it's cache key..

This PR implements `equals()` all the cache keys and updates the `NotificationTypeCacheKey` also to follow the consistency of the implementation.

### When should this PR be merged

Immediate


### Follow up actions

N/A