### PR TITLE
Provide support for In-memory template manager

### DIFF
--- a/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/EmailTemplateManagerImpl.java
+++ b/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/EmailTemplateManagerImpl.java
@@ -22,8 +22,8 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.email.mgt.constants.I18nMgtConstants;
+import org.wso2.carbon.email.mgt.store.DefaultTemplateManager;
 import org.wso2.carbon.email.mgt.store.TemplatePersistenceManager;
-import org.wso2.carbon.email.mgt.store.TemplatePersistenceManagerFactory;
 import org.wso2.carbon.email.mgt.exceptions.I18nEmailMgtClientException;
 import org.wso2.carbon.email.mgt.exceptions.I18nEmailMgtException;
 import org.wso2.carbon.email.mgt.exceptions.I18nEmailMgtInternalException;
@@ -78,8 +78,8 @@ public class EmailTemplateManagerImpl implements EmailTemplateManager, Notificat
     }
 
     public EmailTemplateManagerImpl() {
-        TemplatePersistenceManagerFactory templatePersistenceManagerFactory = new TemplatePersistenceManagerFactory();
-        templatePersistenceManager = templatePersistenceManagerFactory.getTemplatePersistenceManager();
+
+        this.templatePersistenceManager = new DefaultTemplateManager();
     }
 
     @Override

--- a/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/internal/I18nMgtServiceComponent.java
+++ b/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/internal/I18nMgtServiceComponent.java
@@ -87,6 +87,12 @@ public class I18nMgtServiceComponent {
         try {
             BundleContext bundleCtx = context.getBundleContext();
 
+            // Load default notification templates from file
+            I18nMgtDataHolder.getInstance().setDefaultEmailTemplates(
+                    loadDefaultTemplatesFromFile(NotificationChannels.EMAIL_CHANNEL.getChannelType()));
+            I18nMgtDataHolder.getInstance().setDefaultSMSTemplates(
+                    loadDefaultTemplatesFromFile(NotificationChannels.SMS_CHANNEL.getChannelType()));
+
             // Register Email Mgt Service as an OSGi service.
             EmailTemplateManagerImpl emailTemplateManager = new EmailTemplateManagerImpl();
             ServiceRegistration emailTemplateSR = bundleCtx.registerService(EmailTemplateManager.class.getName(),
@@ -134,12 +140,6 @@ public class I18nMgtServiceComponent {
             } else {
                 log.error("Error registering SMS Provider Payload Template Mgt Service.");
             }
-
-            // Load default notification templates from file
-            I18nMgtDataHolder.getInstance().setDefaultEmailTemplates(
-                    loadDefaultTemplatesFromFile(NotificationChannels.EMAIL_CHANNEL.getChannelType()));
-            I18nMgtDataHolder.getInstance().setDefaultSMSTemplates(
-                    loadDefaultTemplatesFromFile(NotificationChannels.SMS_CHANNEL.getChannelType()));
 
             // Load default notification templates.
             loadDefaultEmailTemplates();

--- a/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/store/DefaultTemplateManager.java
+++ b/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/store/DefaultTemplateManager.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.email.mgt.store;
+
+import org.wso2.carbon.identity.governance.exceptions.notiification.NotificationTemplateManagerServerException;
+import org.wso2.carbon.identity.governance.model.NotificationTemplate;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * This class serves as a unified template management system that delegates the template persistence operations
+ * to both template persistent manger crafted from the factory  and an in-memory manager.
+ * This class will function as a wrapper class for the template manager produced from the factory.
+ */
+public class DefaultTemplateManager implements TemplatePersistenceManager {
+
+    private final TemplatePersistenceManager templatePersistenceManager;
+    private final TemplatePersistenceManager inMemoryTemplateManager = new InMemoryBasedTemplateManager();
+
+    public DefaultTemplateManager() {
+
+        TemplatePersistenceManagerFactory templatePersistenceManagerFactory = new TemplatePersistenceManagerFactory();
+        this.templatePersistenceManager = templatePersistenceManagerFactory.getTemplatePersistenceManager();
+    }
+
+    @Override
+    public void addNotificationTemplateType(String displayName, String notificationChannel, String tenantDomain)
+            throws NotificationTemplateManagerServerException {
+
+        templatePersistenceManager.addNotificationTemplateType(displayName, notificationChannel, tenantDomain);
+    }
+
+    @Override
+    public boolean isNotificationTemplateTypeExists(String displayName, String notificationChannel, String tenantDomain)
+            throws NotificationTemplateManagerServerException {
+
+        return templatePersistenceManager.isNotificationTemplateTypeExists(displayName, notificationChannel,
+                tenantDomain) ||
+                inMemoryTemplateManager.isNotificationTemplateTypeExists(displayName, notificationChannel,
+                        tenantDomain);
+    }
+
+    @Override
+    public List<String> listNotificationTemplateTypes(String notificationChannel, String tenantDomain)
+            throws NotificationTemplateManagerServerException {
+
+        List<String> dbBasedTemplateTypes = templatePersistenceManager.listNotificationTemplateTypes
+                (notificationChannel, tenantDomain);
+        List<String> inMemoryTemplateTypes = inMemoryTemplateManager.listNotificationTemplateTypes(notificationChannel,
+                tenantDomain);
+
+        return mergeAndRemoveDuplicates(dbBasedTemplateTypes, inMemoryTemplateTypes);
+    }
+
+    @Override
+    public void deleteNotificationTemplateType(String displayName, String notificationChannel, String tenantDomain)
+            throws NotificationTemplateManagerServerException {
+
+        if (templatePersistenceManager.isNotificationTemplateTypeExists(displayName, notificationChannel,
+                tenantDomain)) {
+            templatePersistenceManager.deleteNotificationTemplateType(displayName, notificationChannel, tenantDomain);
+        }
+    }
+
+    @Override
+    public void addOrUpdateNotificationTemplate(NotificationTemplate notificationTemplate, String applicationUuid,
+                                                String tenantDomain) throws NotificationTemplateManagerServerException {
+
+        templatePersistenceManager.addOrUpdateNotificationTemplate(notificationTemplate, applicationUuid, tenantDomain);
+    }
+
+    @Override
+    public boolean isNotificationTemplateExists(String displayName, String locale, String notificationChannel,
+                                                String applicationUuid, String tenantDomain)
+            throws NotificationTemplateManagerServerException {
+
+        return templatePersistenceManager.isNotificationTemplateExists(displayName, locale, notificationChannel,
+                applicationUuid, tenantDomain) ||
+                inMemoryTemplateManager.isNotificationTemplateExists(displayName, locale, notificationChannel,
+                        applicationUuid, tenantDomain);
+    }
+
+    @Override
+    public NotificationTemplate getNotificationTemplate(String displayName, String locale, String notificationChannel,
+                                                        String applicationUuid, String tenantDomain)
+            throws NotificationTemplateManagerServerException {
+
+        if (templatePersistenceManager.isNotificationTemplateExists(displayName, locale, notificationChannel,
+                applicationUuid, tenantDomain)) {
+            return templatePersistenceManager.getNotificationTemplate(displayName, locale, notificationChannel,
+                    applicationUuid, tenantDomain);
+        } else {
+            return inMemoryTemplateManager.getNotificationTemplate(displayName, locale, notificationChannel,
+                    applicationUuid, tenantDomain);
+        }
+    }
+
+    @Override
+    public List<NotificationTemplate> listNotificationTemplates(String templateType, String notificationChannel,
+                                                                String applicationUuid, String tenantDomain)
+            throws NotificationTemplateManagerServerException {
+
+        List<NotificationTemplate> dbBasedTemplates = new ArrayList<>();
+        if (templatePersistenceManager.isNotificationTemplateTypeExists(templateType, notificationChannel,
+                tenantDomain)) {
+            dbBasedTemplates =
+                    templatePersistenceManager.listNotificationTemplates(templateType, notificationChannel,
+                            applicationUuid, tenantDomain);
+        }
+
+        List<NotificationTemplate> inMemoryBasedTemplates = new ArrayList<>();
+        if (inMemoryTemplateManager.isNotificationTemplateTypeExists(templateType, notificationChannel,
+                tenantDomain)) {
+            inMemoryBasedTemplates =
+                    inMemoryTemplateManager.listNotificationTemplates(templateType, notificationChannel,
+                            applicationUuid, tenantDomain);
+        }
+
+        return mergeAndRemoveDuplicateTemplates(dbBasedTemplates, inMemoryBasedTemplates);
+    }
+
+    @Override
+    public List<NotificationTemplate> listAllNotificationTemplates(String notificationChannel, String tenantDomain)
+            throws NotificationTemplateManagerServerException {
+
+        List<NotificationTemplate> dbBasedTemplates =
+                templatePersistenceManager.listAllNotificationTemplates(notificationChannel, tenantDomain);
+        List<NotificationTemplate> inMemoryBasedTemplates =
+                inMemoryTemplateManager.listAllNotificationTemplates(notificationChannel, tenantDomain);
+
+        return mergeAndRemoveDuplicateTemplates(dbBasedTemplates, inMemoryBasedTemplates);
+    }
+
+    @Override
+    public void deleteNotificationTemplate(String displayName, String locale, String notificationChannel,
+                                           String applicationUuid, String tenantDomain)
+            throws NotificationTemplateManagerServerException {
+
+        if (templatePersistenceManager.isNotificationTemplateExists(displayName, locale, notificationChannel,
+                applicationUuid, tenantDomain)) {
+            templatePersistenceManager.deleteNotificationTemplate(displayName, locale, notificationChannel, applicationUuid,
+                    tenantDomain);
+        }
+    }
+
+    @Override
+    public void deleteNotificationTemplates(String displayName, String notificationChannel, String applicationUuid,
+                                            String tenantDomain) throws NotificationTemplateManagerServerException {
+
+        if (templatePersistenceManager.isNotificationTemplateTypeExists(displayName, notificationChannel,
+                tenantDomain)) {
+            templatePersistenceManager.deleteNotificationTemplates(displayName, notificationChannel, applicationUuid,
+                    tenantDomain);
+        }
+    }
+
+    /**
+     * Merges two lists and removes duplicates.
+     *
+     * @param dbBasedTemplates DbBasedTemplates
+     * @param inMemoryTemplates InMemoryTemplates
+     * @return Merged list without duplicates.
+     */
+    private <T> List<T> mergeAndRemoveDuplicates(List<T> dbBasedTemplates, List<T> inMemoryTemplates) {
+
+        Set<T> uniqueElements = new HashSet<>();
+        uniqueElements.addAll(dbBasedTemplates);
+        uniqueElements.addAll(inMemoryTemplates);
+        return new ArrayList<>(uniqueElements);
+    }
+
+    /**
+     * Merges two NotificationTemplate lists and removes duplicate templates.
+     *
+     * @param dbBasedTemplates DbBasedTemplates
+     * @param inMemoryTemplates InMemoryTemplates
+     * @return Merged list without duplicates.
+     */
+    private List<NotificationTemplate> mergeAndRemoveDuplicateTemplates(
+            List<NotificationTemplate> dbBasedTemplates,
+            List<NotificationTemplate> inMemoryTemplates) {
+
+        Map<String, NotificationTemplate> templateMap = new HashMap<>();
+        dbBasedTemplates.forEach(template -> templateMap.put(template.getDisplayName(), template));
+
+        // Add in-memory templates, only if not already present
+        inMemoryTemplates.forEach(template -> templateMap.putIfAbsent(template.getDisplayName(), template));
+        return new ArrayList<>(templateMap.values());
+    }
+}

--- a/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/store/InMemoryBasedTemplateManager.java
+++ b/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/store/InMemoryBasedTemplateManager.java
@@ -1,0 +1,263 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.email.mgt.store;
+
+import org.apache.commons.lang.StringUtils;
+import org.wso2.carbon.email.mgt.internal.I18nMgtDataHolder;
+import org.wso2.carbon.identity.governance.exceptions.notiification.NotificationTemplateManagerServerException;
+import org.wso2.carbon.identity.governance.model.NotificationTemplate;
+import org.wso2.carbon.identity.governance.service.notification.NotificationChannels;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This class is responsible for storing notification templates from the email-admin-config.xml file.
+ * This class is primarily used to provide default notification templates without addition/modification,
+ * allowing for quick access of templates without migration.
+ * Templates are stored in nested maps, where the outer map is keyed by the template display name and the inner map
+ * is keyed by locale. This allows for easy retrieval of localized templates.
+ * This class used by {@link HybridTemplateManager} as a fallback mechanism.
+ * This class only supports for tenant specific notification templates.
+ */
+public class InMemoryBasedTemplateManager implements TemplatePersistenceManager {
+
+    private final Map<String, Map<String, NotificationTemplate>> defaultEmailTemplates;
+    private final Map<String, Map<String, NotificationTemplate>> defaultSMSTemplates;
+
+    /**
+     * Initializes the in-memory template manager by populating default email and SMS templates.
+     */
+    public InMemoryBasedTemplateManager() {
+
+        defaultEmailTemplates = populateTemplates(I18nMgtDataHolder.getInstance().getDefaultEmailTemplates());
+        defaultSMSTemplates = populateTemplates(I18nMgtDataHolder.getInstance().getDefaultSMSTemplates());
+    }
+
+    @Override
+    public void addNotificationTemplateType(String displayName, String notificationChannel, String tenantDomain)
+            throws NotificationTemplateManagerServerException {
+
+        // This method does nothing cause addition is not allowed for in-memory template manager.
+    }
+
+    /**
+     * Checks if a notification template type exists in the in-memory store.
+     *
+     * @param displayName         The display name of the template type.
+     * @param notificationChannel The channel of the notification (e.g., Email, SMS).
+     * @param tenantDomain        The tenant domain.
+     * @return true if the template type exists, false otherwise.
+     * @throws NotificationTemplateManagerServerException if an error occurs during the operation.
+     */
+    @Override
+    public boolean isNotificationTemplateTypeExists(String displayName, String notificationChannel, String tenantDomain)
+            throws NotificationTemplateManagerServerException {
+
+        if (!StringUtils.isBlank(displayName)) {
+            if (NotificationChannels.SMS_CHANNEL.getChannelType().equals(notificationChannel)) {
+                return defaultSMSTemplates.containsKey(displayName.toLowerCase());
+            }
+            return defaultEmailTemplates.containsKey(displayName.toLowerCase());
+        }
+        return false;
+    }
+
+    /**
+     * Lists all notification template types for a given channel in the in-memory store.
+     *
+     * @param notificationChannel The channel of the notification (e.g., Email, SMS).
+     * @param tenantDomain        The tenant domain.
+     * @return A list of template type display names.
+     * @throws NotificationTemplateManagerServerException if an error occurs during the operation.
+     */
+
+    @Override
+    public List<String> listNotificationTemplateTypes(String notificationChannel, String tenantDomain)
+            throws NotificationTemplateManagerServerException {
+
+        List<String> displayNames = new ArrayList<>();
+        Map<String, Map<String, NotificationTemplate>> defaultTemplates =  getTemplateMap(notificationChannel);
+        defaultTemplates.forEach((displayName, innerMap) ->
+                innerMap.forEach((locale, template) ->
+                        displayNames.add(template.getDisplayName())
+                )
+        );
+        return displayNames;
+    }
+
+    @Override
+    public void deleteNotificationTemplateType(String displayName, String notificationChannel, String tenantDomain)
+            throws NotificationTemplateManagerServerException {
+
+        // This method does nothing cause deletion is not allowed for in-memory template manager.
+    }
+
+    @Override
+    public void addOrUpdateNotificationTemplate(NotificationTemplate notificationTemplate, String applicationUuid,
+                                                String tenantDomain) throws NotificationTemplateManagerServerException {
+
+        // This method does nothing cause modification is not allowed for in-memory template manager.
+    }
+
+    /**
+     * Checks if a specific notification template exists in the in-memory store.
+     *
+     * @param displayName         The display name of the template.
+     * @param locale              The locale of the template.
+     * @param notificationChannel The channel of the notification (e.g., Email, SMS).
+     * @param applicationUuid     The application UUID.
+     * @param tenantDomain        The tenant domain.
+     * @return true if the template exists, false otherwise.
+     * @throws NotificationTemplateManagerServerException if an error occurs during the operation.
+     */
+    @Override
+    public boolean isNotificationTemplateExists(String displayName, String locale, String notificationChannel,
+                                                String applicationUuid, String tenantDomain)
+            throws NotificationTemplateManagerServerException {
+
+        if (StringUtils.isBlank(applicationUuid) && !StringUtils.isBlank(displayName) && !StringUtils.isBlank(locale)) {
+            Map<String, Map<String, NotificationTemplate>> defaultTemplates =  getTemplateMap(notificationChannel);
+            return defaultTemplates.containsKey(displayName.toLowerCase()) &&
+                    defaultTemplates.get(displayName.toLowerCase()).containsKey(locale.toLowerCase());
+        }
+        return false;
+    }
+
+    /**
+     * Retrieves a specific notification template from the in-memory store.
+     *
+     * @param displayName         The display name of the template.
+     * @param locale              The locale of the template.
+     * @param notificationChannel The channel of the notification (e.g., Email, SMS).
+     * @param applicationUuid     The application UUID.
+     * @param tenantDomain        The tenant domain.
+     * @return The notification template, or null if it doesn't exist.
+     * @throws NotificationTemplateManagerServerException if an error occurs during the operation.
+     */
+    @Override
+    public NotificationTemplate getNotificationTemplate(String displayName, String locale, String notificationChannel,
+                                                        String applicationUuid, String tenantDomain)
+            throws NotificationTemplateManagerServerException {
+
+        if (StringUtils.isBlank(applicationUuid) && !StringUtils.isBlank(displayName) && !StringUtils.isBlank(locale)) {
+
+            Map<String, Map<String, NotificationTemplate>> defaultTemplates =  getTemplateMap(notificationChannel);
+            return defaultTemplates.containsKey(displayName.toLowerCase()) ?
+                    defaultTemplates.get(displayName.toLowerCase()).get(locale.toLowerCase()) : null;
+        }
+        return null;
+
+    }
+
+    /**
+     * Lists all notification templates of a specific type for a given channel in the in-memory store.
+     *
+     * @param templateType        The type of the templates to list.
+     * @param notificationChannel The channel of the notification (e.g., Email, SMS).
+     * @param applicationUuid     The application UUID.
+     * @param tenantDomain        The tenant domain.
+     * @return A list of notification templates.
+     * @throws NotificationTemplateManagerServerException if an error occurs during the operation.
+     */
+    @Override
+    public List<NotificationTemplate> listNotificationTemplates(String templateType, String notificationChannel,
+                                                                String applicationUuid, String tenantDomain)
+            throws NotificationTemplateManagerServerException {
+
+        if (StringUtils.isBlank(applicationUuid) && !StringUtils.isBlank(templateType)) {
+            List<NotificationTemplate> notificationTemplates = new ArrayList<>();
+            Map<String, Map<String, NotificationTemplate>> defaultTemplates =  getTemplateMap(notificationChannel);
+            if (defaultTemplates.containsKey(templateType.toLowerCase())) {
+                defaultTemplates.get(templateType.toLowerCase()).forEach((locale, template) ->
+                        notificationTemplates.add(template));
+                return notificationTemplates;
+
+            }
+        }
+        return Collections.emptyList();
+    }
+
+    /**
+     * Lists all notification templates for a given channel in the in-memory store.
+     *
+     * @param notificationChannel The channel of the notification (e.g., Email, SMS).
+     * @param tenantDomain        The tenant domain.
+     * @return A list of notification templates.
+     * @throws NotificationTemplateManagerServerException if an error occurs during the operation.
+     */
+    @Override
+    public List<NotificationTemplate> listAllNotificationTemplates(String notificationChannel, String tenantDomain)
+            throws NotificationTemplateManagerServerException {
+
+        if (NotificationChannels.SMS_CHANNEL.getChannelType().equals(notificationChannel)) {
+            return I18nMgtDataHolder.getInstance().getDefaultSMSTemplates();
+        }
+        return I18nMgtDataHolder.getInstance().getDefaultEmailTemplates();
+    }
+
+    @Override
+    public void deleteNotificationTemplate(String displayName, String locale, String notificationChannel,
+                                           String applicationUuid, String tenantDomain)
+            throws NotificationTemplateManagerServerException {
+
+        // This method does nothing cause deletion is not allowed for in-memory template manager.
+    }
+
+    @Override
+    public void deleteNotificationTemplates(String displayName, String notificationChannel, String applicationUuid,
+                                            String tenantDomain) throws NotificationTemplateManagerServerException {
+
+        // This method does nothing cause deletion is not allowed for in-memory template manager.
+    }
+
+    /**
+     * Populates the in-memory store with default templates, organizing them by display name and locale.
+     *
+     * @param templates The list of templates to populate the store with.
+     * @return A map of template display names to maps of locale to templates.
+     */
+    private Map<String, Map<String, NotificationTemplate>> populateTemplates (List<NotificationTemplate> templates) {
+
+        Map<String, Map<String, NotificationTemplate>> templateMap = new HashMap<>();
+
+        for (NotificationTemplate template : templates) {
+            templateMap.computeIfAbsent(template.getDisplayName().toLowerCase(), k -> new HashMap<>())
+                    .put(template.getLocale().toLowerCase(), template);
+        }
+        return templateMap;
+    }
+
+    /**
+     * Retrieves the map of templates for a given notification channel (e.g., Email, SMS).
+     *
+     * @param notificationChannel The channel of the notification.
+     * @return The map of templates, organized by display name and locale.
+     */
+    private Map<String, Map<String, NotificationTemplate>> getTemplateMap(String notificationChannel) {
+
+        if (NotificationChannels.SMS_CHANNEL.getChannelType().equals(notificationChannel)) {
+            return defaultSMSTemplates;
+        }
+        return defaultEmailTemplates;
+    }
+}

--- a/components/email-mgt/org.wso2.carbon.email.mgt/src/test/java/org/wso2/carbon/email/mgt/store/InMemoryBasedTemplateManagerTest.java
+++ b/components/email-mgt/org.wso2.carbon.email.mgt/src/test/java/org/wso2/carbon/email/mgt/store/InMemoryBasedTemplateManagerTest.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.email.mgt.store;
+
+import org.apache.commons.lang.StringUtils;
+import org.mockito.Mock;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.testng.PowerMockTestCase;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.wso2.carbon.email.mgt.internal.I18nMgtDataHolder;
+import org.wso2.carbon.email.mgt.internal.I18nMgtServiceComponent;
+import org.wso2.carbon.identity.governance.model.NotificationTemplate;
+import org.wso2.carbon.identity.governance.service.notification.NotificationChannels;
+import org.wso2.carbon.utils.CarbonUtils;
+
+import java.nio.file.Paths;
+import java.util.List;
+
+import static org.mockito.MockitoAnnotations.initMocks;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Class that contains the test cases for {@link InMemoryBasedTemplateManager}.
+ */
+@PrepareForTest({I18nMgtDataHolder.class, CarbonUtils.class})
+public class InMemoryBasedTemplateManagerTest extends PowerMockTestCase {
+
+    private final String baseDirectoryPath = Paths.get(System.getProperty("user.dir"),
+            "src", "test", "resources").toString();
+    private static final String tenantDomain = "carbon.super";
+    private static final String dummyDisplayName = "dummyDisplayName";
+    private static final String dummyAppId = "dummyAppId";
+    private static final String EN_US = "en_US";
+    @Mock
+    I18nMgtDataHolder i18nMgtDataHolder;
+    InMemoryBasedTemplateManager inMemoryBasedTemplateManager;
+    NotificationTemplate positiveNotificationTemplate;
+    NotificationTemplate negativeNotificationTemplate;
+
+    @BeforeMethod
+    public void setUp() {
+
+        initMocks(this);
+        mockStatic(I18nMgtDataHolder.class);
+        i18nMgtDataHolder = PowerMockito.mock(I18nMgtDataHolder.class);
+        when(I18nMgtDataHolder.getInstance()).thenReturn(i18nMgtDataHolder);
+
+        List<NotificationTemplate> defaultEmailTemplate = loadDefaultTemplatesFromFile(baseDirectoryPath,
+                NotificationChannels.EMAIL_CHANNEL.getChannelType());
+        when(i18nMgtDataHolder.getDefaultEmailTemplates()).thenReturn(defaultEmailTemplate);
+
+        inMemoryBasedTemplateManager = new InMemoryBasedTemplateManager();
+        initTestNotificationTemplates();
+    }
+
+    private void initTestNotificationTemplates() {
+
+        positiveNotificationTemplate = i18nMgtDataHolder.getDefaultEmailTemplates().get(0);
+        negativeNotificationTemplate = new NotificationTemplate();
+        negativeNotificationTemplate.setNotificationChannel(NotificationChannels.EMAIL_CHANNEL.getChannelType());
+        negativeNotificationTemplate.setType("dummyType");
+        negativeNotificationTemplate.setDisplayName("dummyDisplayName");
+        negativeNotificationTemplate.setLocale("en_US");
+    }
+
+    @Test
+    public void testIsNotificationTemplateTypeExists() throws Exception {
+
+        assertFalse(inMemoryBasedTemplateManager.isNotificationTemplateTypeExists(StringUtils.EMPTY,
+                NotificationChannels.EMAIL_CHANNEL.getChannelType(), tenantDomain));
+        assertFalse(inMemoryBasedTemplateManager.isNotificationTemplateTypeExists(
+                negativeNotificationTemplate.getDisplayName(),
+                NotificationChannels.EMAIL_CHANNEL.getChannelType(), tenantDomain));
+        assertTrue(inMemoryBasedTemplateManager.isNotificationTemplateTypeExists(
+                positiveNotificationTemplate.getDisplayName(),
+                NotificationChannels.EMAIL_CHANNEL.getChannelType(), tenantDomain));
+    }
+
+    @Test
+    public void testListNotificationTemplateTypes() throws Exception {
+
+        List<String> displayNames = inMemoryBasedTemplateManager.listNotificationTemplateTypes(
+                NotificationChannels.EMAIL_CHANNEL.getChannelType(), tenantDomain);
+        assertNotNull(displayNames);
+        assertTrue(displayNames.contains(positiveNotificationTemplate.getDisplayName()));
+        assertFalse(displayNames.contains(negativeNotificationTemplate.getDisplayName()));
+    }
+
+    @Test
+    public void testIsNotificationTemplateExists() throws Exception {
+
+        assertFalse(inMemoryBasedTemplateManager.isNotificationTemplateExists(StringUtils.EMPTY, EN_US,
+                NotificationChannels.EMAIL_CHANNEL.getChannelType(), dummyAppId, tenantDomain));
+        assertFalse(inMemoryBasedTemplateManager.isNotificationTemplateExists(dummyDisplayName, StringUtils.EMPTY,
+                NotificationChannels.EMAIL_CHANNEL.getChannelType(), dummyAppId, tenantDomain));
+        assertFalse(inMemoryBasedTemplateManager.isNotificationTemplateExists(dummyDisplayName, EN_US,
+                NotificationChannels.EMAIL_CHANNEL.getChannelType(), StringUtils.EMPTY, tenantDomain));
+        assertFalse(inMemoryBasedTemplateManager.isNotificationTemplateExists(
+                negativeNotificationTemplate.getDisplayName(), EN_US,
+                NotificationChannels.EMAIL_CHANNEL.getChannelType(), StringUtils.EMPTY, tenantDomain));
+        assertTrue(inMemoryBasedTemplateManager.isNotificationTemplateExists(
+                positiveNotificationTemplate.getDisplayName(), EN_US,
+                NotificationChannels.EMAIL_CHANNEL.getChannelType(), StringUtils.EMPTY, tenantDomain));
+    }
+
+    @Test
+    public void testGetNotificationTemplate() throws Exception {
+
+        assertNull(inMemoryBasedTemplateManager.getNotificationTemplate(StringUtils.EMPTY, EN_US,
+                NotificationChannels.EMAIL_CHANNEL.getChannelType(), dummyAppId, tenantDomain));
+        assertNull(inMemoryBasedTemplateManager.getNotificationTemplate(dummyDisplayName, StringUtils.EMPTY,
+                NotificationChannels.EMAIL_CHANNEL.getChannelType(), dummyAppId, tenantDomain));
+        assertNull(inMemoryBasedTemplateManager.getNotificationTemplate(dummyDisplayName, EN_US,
+                NotificationChannels.EMAIL_CHANNEL.getChannelType(), StringUtils.EMPTY, tenantDomain));
+        assertNull(inMemoryBasedTemplateManager.getNotificationTemplate(
+                negativeNotificationTemplate.getDisplayName(), EN_US,
+                NotificationChannels.EMAIL_CHANNEL.getChannelType(), StringUtils.EMPTY, tenantDomain));
+        assertNotNull(inMemoryBasedTemplateManager.getNotificationTemplate(
+                positiveNotificationTemplate.getDisplayName(), EN_US,
+                NotificationChannels.EMAIL_CHANNEL.getChannelType(), StringUtils.EMPTY, tenantDomain));
+    }
+
+    @Test
+    public void testListNotificationTemplates() throws Exception {
+
+        assertTrue(inMemoryBasedTemplateManager.listNotificationTemplates(StringUtils.EMPTY,
+                NotificationChannels.EMAIL_CHANNEL.getChannelType(), dummyAppId, tenantDomain).isEmpty());
+        assertTrue(inMemoryBasedTemplateManager.listNotificationTemplates(dummyDisplayName,
+                NotificationChannels.EMAIL_CHANNEL.getChannelType(), StringUtils.EMPTY, tenantDomain).isEmpty());
+        assertTrue(inMemoryBasedTemplateManager.listNotificationTemplates(
+                negativeNotificationTemplate.getDisplayName(),
+                NotificationChannels.EMAIL_CHANNEL.getChannelType(), StringUtils.EMPTY, tenantDomain).isEmpty());
+        assertFalse(inMemoryBasedTemplateManager.listNotificationTemplates(
+                positiveNotificationTemplate.getDisplayName(),
+                NotificationChannels.EMAIL_CHANNEL.getChannelType(), StringUtils.EMPTY, tenantDomain).isEmpty());
+    }
+
+    @Test
+    public void testListAllNotificationTemplates() throws Exception {
+
+        assertFalse(inMemoryBasedTemplateManager.listAllNotificationTemplates(
+                NotificationChannels.EMAIL_CHANNEL.getChannelType(), tenantDomain).isEmpty());
+        assertTrue(inMemoryBasedTemplateManager.listAllNotificationTemplates(
+                NotificationChannels.SMS_CHANNEL.getChannelType(), tenantDomain).isEmpty());
+    }
+
+    /**
+     * Loads the default templates from the file for the channel(EMAIL or SMS) and create list of Notification Template.
+     *
+     * @param notificationChannel   Channel of the notification.
+     * @return                      List of NotificationTemplate.
+     */
+    private List<NotificationTemplate> loadDefaultTemplatesFromFile(String baseDirectoryPath,
+                                                                    String notificationChannel) {
+
+        mockNotificationChannelConfigPath(baseDirectoryPath);
+        I18nMgtServiceComponent component = new I18nMgtServiceComponent();
+        return component.loadDefaultTemplatesFromFile(notificationChannel);
+    }
+
+    /**
+     * Mock the default config xml path of notification templates.
+     *
+     * @param baseDirectoryPath Resource folder location
+     */
+    private void mockNotificationChannelConfigPath(String baseDirectoryPath) {
+
+        mockStatic(CarbonUtils.class);
+        when(CarbonUtils.getCarbonConfigDirPath()).thenReturn(baseDirectoryPath);
+    }
+}

--- a/components/email-mgt/org.wso2.carbon.email.mgt/src/test/resources/testng.xml
+++ b/components/email-mgt/org.wso2.carbon.email.mgt/src/test/resources/testng.xml
@@ -20,6 +20,7 @@
 
     <test name="EmailMgtTests" preserve-order="true" parallel="false">
         <classes>
+            <class name="org.wso2.carbon.email.mgt.store.InMemoryBasedTemplateManagerTest"/>
             <class name="org.wso2.carbon.email.mgt.store.TemplatePersistenceManagerFactoryTest"/>
             <class name="org.wso2.carbon.email.mgt.OrganizationEmailTemplateTest"/>
             <class name="org.wso2.carbon.email.mgt.ApplicationEmailTemplateTest"/>


### PR DESCRIPTION
### Proposed changes in this pull request

Currently email/sms templates are stored in the registry, for any sub tenants we are **not adding new templates** when server startup. When creating any tenants we are adding default email templates to the registry per tenant, this leaves **redundant data**. With this fix, we are providing In-memory template manager which return dafault templates and act on read only mode.

Currently, it works with hybrid template manager and db-based template manager also.

TODO:

- [x] Unittests