### PR TITLE
Refactor the code to utilize the application management service for retrieving the main application ID

### DIFF
--- a/components/email-mgt/org.wso2.carbon.email.mgt/pom.xml
+++ b/components/email-mgt/org.wso2.carbon.email.mgt/pom.xml
@@ -81,6 +81,10 @@
             <artifactId>org.wso2.carbon.identity.application.mgt</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.application.common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.carbon.commons</groupId>
             <artifactId>org.wso2.carbon.tenant.common</artifactId>
         </dependency>
@@ -161,6 +165,7 @@
                             org.wso2.carbon.registry.core.*;version="${carbon.kernel.registry.imp.pkg.version}",
                             org.wso2.carbon.identity.base; version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.application.mgt; version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.application.common; version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.governance.*;version="${identity.governance.imp.pkg.version.range}",
                             org.wso2.carbon.database.utils.*;version="${org.wso2.carbon.database.utils.version.range}",
                             org.wso2.carbon.identity.organization.management.service;

--- a/components/email-mgt/org.wso2.carbon.email.mgt/pom.xml
+++ b/components/email-mgt/org.wso2.carbon.email.mgt/pom.xml
@@ -257,6 +257,12 @@
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>${jacoco.version}</version>
+                <configuration>
+                    <excludes>
+                        <exclude>org/wso2/carbon/email/mgt/internal/I18nMgtServiceComponent.class</exclude>
+                        <exclude>org/wso2/carbon/email/mgt/internal/I18nMgtDataHolder.class</exclude>
+                    </excludes>
+                </configuration>
                 <executions>
                     <execution>
                         <goals>

--- a/components/email-mgt/org.wso2.carbon.email.mgt/pom.xml
+++ b/components/email-mgt/org.wso2.carbon.email.mgt/pom.xml
@@ -53,10 +53,6 @@
             <artifactId>org.wso2.carbon.user.core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.carbon.identity.organization.management</groupId>
-            <artifactId>org.wso2.carbon.identity.organization.management.application</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.wso2.carbon</groupId>
             <artifactId>javax.cache.wso2</artifactId>
         </dependency>
@@ -79,6 +75,10 @@
         <dependency>
             <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.application.mgt</artifactId>
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon.commons</groupId>
@@ -160,6 +160,7 @@
                             org.wso2.carbon.identity.core.*; version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.registry.core.*;version="${carbon.kernel.registry.imp.pkg.version}",
                             org.wso2.carbon.identity.base; version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.application.mgt; version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.governance.*;version="${identity.governance.imp.pkg.version.range}",
                             org.wso2.carbon.database.utils.*;version="${org.wso2.carbon.database.utils.version.range}",
                             org.wso2.carbon.identity.organization.management.service;
@@ -168,8 +169,6 @@
                             version="${org.wso2.identity.organization.mgt.core.imp.pkg.version.range}",
                             org.wso2.carbon.identity.organization.management.service.exception;
                             version="${org.wso2.identity.organization.mgt.core.imp.pkg.version.range}",
-                            org.wso2.carbon.identity.organization.management.application.*;
-                            version="${org.wso2.identity.organization.mgt.imp.pkg.version.range}",
                         </Import-Package>
                     </instructions>
                 </configuration>

--- a/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/EmailTemplateManagerImpl.java
+++ b/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/EmailTemplateManagerImpl.java
@@ -33,7 +33,6 @@ import org.wso2.carbon.email.mgt.exceptions.I18nMgtEmailConfigException;
 import org.wso2.carbon.email.mgt.internal.I18nMgtDataHolder;
 import org.wso2.carbon.email.mgt.model.EmailTemplate;
 import org.wso2.carbon.email.mgt.util.I18nEmailUtil;
-import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementServerException;
 import org.wso2.carbon.identity.base.IdentityValidationUtil;
 import org.wso2.carbon.identity.governance.IdentityGovernanceUtil;

--- a/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/EmailTemplateManagerImpl.java
+++ b/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/EmailTemplateManagerImpl.java
@@ -45,7 +45,6 @@ import org.wso2.carbon.identity.governance.model.NotificationTemplate;
 import org.wso2.carbon.identity.governance.service.notification.NotificationChannels;
 import org.wso2.carbon.identity.governance.service.notification.NotificationTemplateManager;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
-import org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
 import org.wso2.carbon.identity.organization.management.service.util.OrganizationManagementUtil;
 

--- a/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/EmailTemplateManagerImpl.java
+++ b/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/EmailTemplateManagerImpl.java
@@ -34,6 +34,7 @@ import org.wso2.carbon.email.mgt.internal.I18nMgtDataHolder;
 import org.wso2.carbon.email.mgt.model.EmailTemplate;
 import org.wso2.carbon.email.mgt.util.I18nEmailUtil;
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
+import org.wso2.carbon.identity.application.common.IdentityApplicationManagementServerException;
 import org.wso2.carbon.identity.base.IdentityValidationUtil;
 import org.wso2.carbon.identity.governance.IdentityGovernanceUtil;
 import org.wso2.carbon.identity.governance.IdentityMgtConstants;
@@ -296,7 +297,7 @@ public class EmailTemplateManagerImpl implements EmailTemplateManager, Notificat
             }
         } catch (OrganizationManagementException e) {
             throw new NotificationTemplateManagerException(e.getMessage(), e);
-        } catch (IdentityApplicationManagementException e) {
+        } catch (IdentityApplicationManagementServerException e) {
             throw new NotificationTemplateManagerException(ERROR_CODE_ERROR_RESOLVING_MAIN_APPLICATION.getCode(),
                     ERROR_CODE_ERROR_RESOLVING_MAIN_APPLICATION.getMessage(), e);
         }

--- a/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/internal/I18nMgtDataHolder.java
+++ b/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/internal/I18nMgtDataHolder.java
@@ -47,6 +47,26 @@ public class I18nMgtDataHolder{
         return instance;
     }
 
+    /**
+     * Get the application management service.
+     *
+     * @return Application management service.
+     */
+    public ApplicationManagementService getApplicationManagementService() {
+
+        return applicationManagementService;
+    }
+
+    /**
+     * Set the application management service.
+     *
+     * @param applicationManagementService Application management service instance.
+     */
+    public void setApplicationManagementService(ApplicationManagementService applicationManagementService) {
+
+        this.applicationManagementService = applicationManagementService;
+    }
+
     public RealmService getRealmService() {
         if (realmService == null) {
             throw new RuntimeException("Realm Service has not been set. Component has not initialized properly.");
@@ -139,25 +159,5 @@ public class I18nMgtDataHolder{
     public List<String> getLegacyTenants() {
 
         return legacyTenants;
-    }
-
-    /**
-     * Get the application management service.
-     *
-     * @return Application management service.
-     */
-    public ApplicationManagementService getApplicationManagementService() {
-
-        return applicationManagementService;
-    }
-
-    /**
-     * Set the application management service.
-     *
-     * @param applicationManagementService Application management service instance.
-     */
-    public void setApplicationManagementService(ApplicationManagementService applicationManagementService) {
-
-        this.applicationManagementService = applicationManagementService;
     }
 }

--- a/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/internal/I18nMgtDataHolder.java
+++ b/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/internal/I18nMgtDataHolder.java
@@ -18,9 +18,9 @@
 
 package org.wso2.carbon.email.mgt.internal;
 
+import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.core.persistence.registry.RegistryResourceMgtService;
 import org.wso2.carbon.identity.governance.model.NotificationTemplate;
-import org.wso2.carbon.identity.organization.management.application.OrgApplicationManager;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.registry.core.service.RegistryService;
 import org.wso2.carbon.user.core.service.RealmService;
@@ -33,7 +33,7 @@ public class I18nMgtDataHolder{
     private RegistryService registryService;
     private RegistryResourceMgtService registryResourceMgtService;
     private OrganizationManager organizationManager;
-    private OrgApplicationManager sharedAppManager;
+    private ApplicationManagementService applicationManagementService;
     private List<NotificationTemplate> defaultEmailTemplates = new ArrayList<>();
     private List<NotificationTemplate> defaultSMSTemplates = new ArrayList<>();
     private List<String> legacyTenants = new ArrayList<>();
@@ -122,26 +122,6 @@ public class I18nMgtDataHolder{
     }
 
     /**
-     * Get the shared application manager.
-     *
-     * @return Shared application manager.
-     */
-    public OrgApplicationManager getSharedAppManager() {
-
-        return sharedAppManager;
-    }
-
-    /**
-     * Set the shared application manager.
-     *
-     * @param sharedAppManager Shared application manager.
-     */
-    public void setSharedAppManager(OrgApplicationManager sharedAppManager) {
-
-        this.sharedAppManager = sharedAppManager;
-    }
-
-    /**
      * Set the list of legacy tenants.
      *
      * @param legacyTenants List of legacy tenants.
@@ -159,5 +139,25 @@ public class I18nMgtDataHolder{
     public List<String> getLegacyTenants() {
 
         return legacyTenants;
+    }
+
+    /**
+     * Get the application management service.
+     *
+     * @return Application management service.
+     */
+    public ApplicationManagementService getApplicationManagementService() {
+
+        return applicationManagementService;
+    }
+
+    /**
+     * Set the application management service.
+     *
+     * @param applicationManagementService Application management service instance.
+     */
+    public void setApplicationManagementService(ApplicationManagementService applicationManagementService) {
+
+        this.applicationManagementService = applicationManagementService;
     }
 }

--- a/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/internal/I18nMgtServiceComponent.java
+++ b/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/internal/I18nMgtServiceComponent.java
@@ -311,6 +311,24 @@ public class I18nMgtServiceComponent {
     }
 
     @Reference(
+            name = "org.wso2.carbon.identity.application.mgt",
+            service = ApplicationManagementService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetApplicationManagementService")
+    protected void setApplicationManagementService(ApplicationManagementService applicationManagementService) {
+
+        log.debug("Setting Application Management Service.");
+        dataHolder.setApplicationManagementService(applicationManagementService);
+    }
+
+    protected void unsetApplicationManagementService(ApplicationManagementService applicationManagementService) {
+
+        log.debug("Unsetting Application Management Service.");
+        dataHolder.setApplicationManagementService(null);
+    }
+
+    @Reference(
              name = "realm.service", 
              service = org.wso2.carbon.user.core.service.RealmService.class, 
              cardinality = ReferenceCardinality.MANDATORY, 
@@ -384,24 +402,6 @@ public class I18nMgtServiceComponent {
     protected void unsetOrganizationManager(OrganizationManager organizationManager) {
 
         dataHolder.getInstance().setOrganizationManager(null);
-    }
-
-    @Reference(
-            name = "org.wso2.carbon.identity.application.mgt",
-            service = ApplicationManagementService.class,
-            cardinality = ReferenceCardinality.MANDATORY,
-            policy = ReferencePolicy.DYNAMIC,
-            unbind = "unsetApplicationManagementService")
-    protected void setApplicationManagementService(ApplicationManagementService applicationManagementService) {
-
-        log.debug("Setting Application Management Service.");
-        dataHolder.setApplicationManagementService(applicationManagementService);
-    }
-
-    protected void unsetApplicationManagementService(ApplicationManagementService applicationManagementService) {
-
-        log.debug("Unsetting Application Management Service.");
-        dataHolder.setApplicationManagementService(null);
     }
 }
 

--- a/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/internal/I18nMgtServiceComponent.java
+++ b/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/internal/I18nMgtServiceComponent.java
@@ -33,13 +33,13 @@ import org.wso2.carbon.email.mgt.SMSProviderPayloadTemplateManagerImpl;
 import org.wso2.carbon.email.mgt.constants.I18nMgtConstants;
 import org.wso2.carbon.email.mgt.exceptions.I18nEmailMgtException;
 import org.wso2.carbon.email.mgt.model.SMSProviderTemplate;
+import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.core.persistence.registry.RegistryResourceMgtService;
 import org.wso2.carbon.identity.governance.exceptions.notiification.NotificationTemplateManagerException;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.governance.model.NotificationTemplate;
 import org.wso2.carbon.identity.governance.service.notification.NotificationChannels;
 import org.wso2.carbon.identity.governance.service.notification.NotificationTemplateManager;
-import org.wso2.carbon.identity.organization.management.application.OrgApplicationManager;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.registry.core.service.RegistryService;
 import org.wso2.carbon.stratos.common.listeners.TenantMgtListener;
@@ -387,19 +387,21 @@ public class I18nMgtServiceComponent {
     }
 
     @Reference(
-            name = "organization.application.management.service",
-            service = OrgApplicationManager.class,
+            name = "org.wso2.carbon.identity.application.mgt",
+            service = ApplicationManagementService.class,
             cardinality = ReferenceCardinality.MANDATORY,
             policy = ReferencePolicy.DYNAMIC,
-            unbind = "unsetOrganizationApplicationManager")
-    protected void setOrganizationApplicationManager(OrgApplicationManager orgApplicationManager) {
+            unbind = "unsetApplicationManagementService")
+    protected void setApplicationManagementService(ApplicationManagementService applicationManagementService) {
 
-        dataHolder.getInstance().setSharedAppManager(orgApplicationManager);
+        log.debug("Setting Application Management Service.");
+        dataHolder.setApplicationManagementService(applicationManagementService);
     }
 
-    protected void unsetOrganizationApplicationManager(OrgApplicationManager orgApplicationManager) {
+    protected void unsetApplicationManagementService(ApplicationManagementService applicationManagementService) {
 
-        dataHolder.getInstance().setSharedAppManager(null);
+        log.debug("Unsetting Application Management Service.");
+        dataHolder.setApplicationManagementService(null);
     }
 }
 

--- a/components/email-mgt/org.wso2.carbon.email.mgt/src/test/java/org/wso2/carbon/email/mgt/ApplicationEmailTemplateTest.java
+++ b/components/email-mgt/org.wso2.carbon.email.mgt/src/test/java/org/wso2/carbon/email/mgt/ApplicationEmailTemplateTest.java
@@ -42,8 +42,6 @@ import org.testng.annotations.Test;
 import org.wso2.carbon.email.mgt.constants.I18nMgtConstants;
 import org.wso2.carbon.email.mgt.internal.I18nMgtDataHolder;
 import org.wso2.carbon.email.mgt.util.I18nEmailUtil;
-import org.wso2.carbon.identity.application.common.IdentityApplicationManagementClientException;
-import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementServerException;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.base.IdentityRuntimeException;
@@ -55,7 +53,6 @@ import org.wso2.carbon.identity.governance.exceptions.notiification.Notification
 import org.wso2.carbon.identity.governance.model.NotificationTemplate;
 import org.wso2.carbon.identity.governance.service.notification.NotificationChannels;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
-import org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants;
 import org.wso2.carbon.identity.organization.management.service.util.OrganizationManagementUtil;
 import org.wso2.carbon.registry.core.Resource;
 import org.wso2.carbon.utils.CarbonUtils;

--- a/pom.xml
+++ b/pom.xml
@@ -164,6 +164,11 @@
                 <artifactId>org.wso2.carbon.identity.application.mgt</artifactId>
                 <version>${carbon.identity.framework.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.application.common</artifactId>
+                <version>${carbon.identity.framework.version}</version>
+            </dependency>
 
             <!--Carbon Analytics Common Dependencies-->
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -276,11 +276,6 @@
                 <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
                 <version>${identity.organization.management.core.version}</version>
             </dependency>
-            <dependency>
-                <groupId>org.wso2.carbon.identity.organization.management</groupId>
-                <artifactId>org.wso2.carbon.identity.organization.management.application</artifactId>
-                <version>${identity.organization.management.version}</version>
-            </dependency>
 
             <!-- Test Dependencies -->
             <dependency>
@@ -527,7 +522,6 @@
 
         <!-- Organization management Version -->
         <identity.organization.management.core.version>1.0.93</identity.organization.management.core.version>
-        <identity.organization.management.version>1.4.14</identity.organization.management.version>
         <org.wso2.identity.organization.mgt.core.imp.pkg.version.range>[1.0.0,2.0.0)
         </org.wso2.identity.organization.mgt.core.imp.pkg.version.range>
         <org.wso2.identity.organization.mgt.imp.pkg.version.range>[1.0.0,2.0.0)


### PR DESCRIPTION
A circular OSGI service dependency arose when implementing the changes related to PR [#2581](https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2581). To address this, the PR proposes a refactoring of the codebase by removing the `OrgApplicationManager` dependency and introducing a framework service to retrieve the main application ID for a specific shared app.