### PR TITLE
Fix default SMS template inconsistent placeholder

### DIFF
--- a/features/org.wso2.carbon.email.mgt.server.feature/resources/sms-templates-admin-config.xml
+++ b/features/org.wso2.carbon.email.mgt.server.feature/resources/sms-templates-admin-config.xml
@@ -42,6 +42,6 @@
         <body>Your Mobile Number Verification Code : {{confirmation-code}}</body>
     </configuration>
     <configuration type="SMSOTP" display="SMSOTP" locale="en_US">
-        <body>Your one-time password for the {{application-name}} is {{otpToken}}. This expires in {{otp-expiry-time}} minutes.</body>
+        <body>Your one-time password for the {{application-name}} is {{confirmation-code}}. This expires in {{otp-expiry-time}} minutes.</body>
     </configuration>
 </configurations>


### PR DESCRIPTION
### Proposed changes in this pull request

- Currently the SMSOTP type system SMS template contains a placeholder `{{otpCode}}`. This is inconsistent with all other OTP templates.
- This PR changes the placeholder value of this template to the commonly used `{{confirmation-code}}`. 
- The necessary code changes for resolving the template is made in the related PRs.

### Related Issue 
- https://github.com/wso2/product-is/issues/21620

### Related PRs
- https://github.com/wso2/carbon-identity-framework/pull/6104
- https://github.com/wso2-extensions/identity-local-auth-smsotp/pull/25

### When to merge
After : 
- https://github.com/wso2-extensions/identity-local-auth-smsotp/pull/25
