### PR TITLE
Introduce On-Demand B2B Child Org Template Migration

### DIFF
--- a/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/store/HybridTemplateManager.java
+++ b/components/email-mgt/org.wso2.carbon.email.mgt/src/main/java/org/wso2/carbon/email/mgt/store/HybridTemplateManager.java
@@ -18,16 +18,31 @@
 
 package org.wso2.carbon.email.mgt.store;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.email.mgt.internal.I18nMgtDataHolder;
+import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
+import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
+import org.wso2.carbon.identity.core.ThreadLocalAwareExecutors;
 import org.wso2.carbon.identity.governance.exceptions.notiification.NotificationTemplateManagerServerException;
 import org.wso2.carbon.identity.governance.model.NotificationTemplate;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
+import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
+import org.wso2.carbon.identity.organization.management.service.model.BasicOrganization;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Base64;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.stream.Collectors;
 
 /**
  * This class is responsible for on-demand migrating notification templates from the registry to the database.
@@ -38,6 +53,7 @@ import java.util.Set;
 public class HybridTemplateManager implements TemplatePersistenceManager {
 
     private static final Log log = LogFactory.getLog(HybridTemplateManager.class);
+    private final ExecutorService executorService = ThreadLocalAwareExecutors.newFixedThreadPool(1);
 
     private TemplatePersistenceManager dbBasedTemplateManager = new DBBasedTemplateManager();
     private TemplatePersistenceManager registryBasedTemplateManager = new RegistryBasedTemplateManager();
@@ -137,6 +153,8 @@ public class HybridTemplateManager implements TemplatePersistenceManager {
 
         if (registryBasedTemplateManager.isNotificationTemplateExists(displayName, locale, notificationChannel,
                 applicationUuid, tenantDomain)) {
+            NotificationTemplate registryBasedTemplate = registryBasedTemplateManager.getNotificationTemplate(displayName,
+                    locale, notificationChannel, applicationUuid, tenantDomain);
 
 //            registryBasedTemplateManager.deleteNotificationTemplate(displayName, locale, notificationChannel,
 //                    applicationUuid, tenantDomain);
@@ -148,6 +166,12 @@ public class HybridTemplateManager implements TemplatePersistenceManager {
                         "Moved %s template: %s for locale: %s in tenant: %s from registry to the database.",
                         notificationChannel, displayName, locale, tenantDomain));
             }
+
+            String usernameInContext = PrivilegedCarbonContext.getThreadLocalCarbonContext().getUsername();
+            CompletableFuture.runAsync(
+                    () -> migrateChildOrgTemplates(registryBasedTemplate, tenantDomain, applicationUuid,
+                            usernameInContext),
+                    executorService);
         }
     }
 
@@ -276,5 +300,90 @@ public class HybridTemplateManager implements TemplatePersistenceManager {
         uniqueElements.addAll(list1);
         uniqueElements.addAll(list2);
         return new ArrayList<>(uniqueElements);
+    }
+
+    private void migrateChildOrgTemplates(NotificationTemplate parentTemplate, String parentTenantDomain,
+                                          String parentAppId, String usernameInContext) {
+
+        String cursor = null;
+        int pageSize = 100;
+        try {
+            String displayName = parentTemplate.getDisplayName();
+            String locale = parentTemplate.getLocale();
+            String notificationChannel = parentTemplate.getNotificationChannel();
+
+            PrivilegedCarbonContext.startTenantFlow();
+            PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain(parentTenantDomain, true);
+            PrivilegedCarbonContext.getThreadLocalCarbonContext().setUsername(usernameInContext);
+
+            OrganizationManager organizationManager = I18nMgtDataHolder.getInstance().getOrganizationManager();
+            ApplicationManagementService applicationManagementService =
+                    I18nMgtDataHolder.getInstance().getApplicationManagementService();
+            do {
+                try {
+                    List<BasicOrganization> childOrganizations =
+                            organizationManager.getOrganizations(pageSize, cursor, null, "DESC", "", false);
+                    Map<String, String> childAppIds = new HashMap<>();
+                    if (StringUtils.isNotBlank(parentAppId)) {
+                        childAppIds = applicationManagementService.getChildAppIds(parentAppId, parentTenantDomain,
+                                childOrganizations.stream().map(BasicOrganization::getId).collect(Collectors.toList()));
+                        if (childAppIds.isEmpty()) {
+                            continue;
+                        }
+                    }
+                    for (BasicOrganization childOrganization : childOrganizations) {
+                        String childTenantDomain = organizationManager.resolveTenantDomain(childOrganization.getId());
+                        String childAppId = childAppIds.get(childTenantDomain);
+
+                        if (StringUtils.isNotBlank(parentAppId) && StringUtils.isBlank(childAppId)) {
+                            continue;
+                        }
+
+                        NotificationTemplate childNotificationTemplate =
+                                registryBasedTemplateManager.getNotificationTemplate(
+                                        displayName, locale, notificationChannel, childAppId, childTenantDomain);
+                        if (childNotificationTemplate != null) {
+                            if (!areNotificationTemplatesEqual(parentTemplate, childNotificationTemplate) &&
+                                    !dbBasedTemplateManager.isNotificationTemplateExists(displayName, locale,
+                                            notificationChannel, childAppId, childTenantDomain)) {
+                                dbBasedTemplateManager.addOrUpdateNotificationTemplate(childNotificationTemplate,
+                                        childAppId, childTenantDomain);
+                            }
+
+                            registryBasedTemplateManager.deleteNotificationTemplates(displayName, notificationChannel,
+                                    childAppId, childTenantDomain);
+                            migrateChildOrgTemplates(childNotificationTemplate, childTenantDomain, childAppId,
+                                    usernameInContext);
+                        }
+                    }
+                    cursor = childOrganizations.isEmpty() ? null : Base64.getEncoder().encodeToString(
+                            childOrganizations.get(childOrganizations.size() - 1).getCreated()
+                                    .getBytes(StandardCharsets.UTF_8));
+                } catch (OrganizationManagementException e) {
+                    log.error("Error occurred while retrieving child organizations of organization " +
+                            "with tenant domain: " + parentTenantDomain, e);
+                } catch (IdentityApplicationManagementException e){
+                    log.error("Error occurred while retrieving child app ids of application with id: " +
+                            parentAppId + " and tenant domain: " + parentTenantDomain, e);
+                } catch (NotificationTemplateManagerServerException e) {
+                    log.error("Error occurred while migrating child organization templates of parent template: " +
+                            displayName + " for locale: " + locale + " and notification channel: " +
+                            notificationChannel, e);
+                }
+            } while (cursor != null);
+        } finally {
+            PrivilegedCarbonContext.endTenantFlow();
+        }
+    }
+
+    private boolean areNotificationTemplatesEqual(NotificationTemplate template1, NotificationTemplate template2) {
+
+        return StringUtils.equals(template1.getDisplayName(), template2.getDisplayName()) &&
+                StringUtils.equals(template1.getLocale(), template2.getLocale()) &&
+                StringUtils.equals(template1.getNotificationChannel(), template2.getNotificationChannel()) &&
+                StringUtils.equals(template1.getContentType(), template2.getContentType()) &&
+                StringUtils.equals(template1.getBody(), template2.getBody()) &&
+                StringUtils.equals(template1.getSubject(), template2.getSubject()) &&
+                StringUtils.equals(template1.getFooter(), template2.getFooter());
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -522,7 +522,7 @@
         <org.wso2.carbon.database.utils.version.range>[2.1.0,3.0.0)</org.wso2.carbon.database.utils.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>7.1.0</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.7.2</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[7.1.0, 8.0.0)</carbon.identity.framework.imp.pkg.version.range>
 
         <!-- Organization management Version -->


### PR DESCRIPTION
### Purpose
- In Hybrid template management mode [1], all notification templates in the child organization tree should be migrated to the database from the regisitry, in order to minimize inconsistencies with the residual migration and to introduce template inheritance to old organizations.
- Hence, this PR introduces on-demand B2B child organization template migration when updating the template of the parent organization.

### Related Issues
- https://github.com/wso2/product-is/issues/21214

[1] - Following config should be added to enabled hybrid template management mode in `deployment.toml`.
```toml
[data_storage_type]
notification_templates = "hybrid"
```