### PR TITLE
Fix issue with inheriting push provider configurations from parent organization

### DIFF
--- a/components/notification-sender-config/org.wso2.carbon.identity.notification.sender.tenant.config/pom.xml
+++ b/components/notification-sender-config/org.wso2.carbon.identity.notification.sender.tenant.config/pom.xml
@@ -56,6 +56,10 @@
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.application.authentication.framework</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.application.mgt</artifactId>
         </dependency>
         <dependency>
@@ -181,6 +185,8 @@
                             org.wso2.carbon.identity.notification.push.provider; version="${identity.notification.push.version.range}",
                             org.wso2.carbon.identity.notification.push.provider.exception; version="${identity.notification.push.version.range}",
                             org.wso2.carbon.identity.notification.push.provider.model; version="${identity.notification.push.version.range}",
+
+                            org.wso2.carbon.identity.application.authentication.framework.util; version="${carbon.identity.framework.imp.pkg.version.range}",
                         </Import-Package>
                     </instructions>
                 </configuration>


### PR DESCRIPTION
When inheriting push provider configurations from the parent organization to sub organization, the secret properties related to push providers will be still stored against the parent organization in the secret management component. Hence, a new tenant flow has to be started with the parent organization to retrieve the correct secret property values from the secret management component. If not, an exception will be since there won't be secrets properties available against the sub organization.

Related issue:
- https://github.com/wso2/product-is/issues/22815