### PR TITLE
Skip the application check for sms provider deletion.

### DIFF
--- a/components/notification-sender-config/org.wso2.carbon.identity.notification.sender.tenant.config/src/main/java/org/wso2/carbon/identity/notification/sender/tenant/config/NotificationSenderManagementServiceImpl.java
+++ b/components/notification-sender-config/org.wso2.carbon.identity.notification.sender.tenant.config/src/main/java/org/wso2/carbon/identity/notification/sender/tenant/config/NotificationSenderManagementServiceImpl.java
@@ -75,6 +75,7 @@ import static org.wso2.carbon.identity.notification.sender.tenant.config.Notific
 import static org.wso2.carbon.identity.notification.sender.tenant.config.NotificationSenderManagementConstants.DEFAULT_EMAIL_PUBLISHER;
 import static org.wso2.carbon.identity.notification.sender.tenant.config.NotificationSenderManagementConstants.DEFAULT_HANDLER_NAME;
 import static org.wso2.carbon.identity.notification.sender.tenant.config.NotificationSenderManagementConstants.DEFAULT_PUSH_PUBLISHER;
+import static org.wso2.carbon.identity.notification.sender.tenant.config.NotificationSenderManagementConstants.DEFAULT_SMS_PUBLISHER;
 import static org.wso2.carbon.identity.notification.sender.tenant.config.NotificationSenderManagementConstants.EMAIL_PUBLISHER_TYPE;
 import static org.wso2.carbon.identity.notification.sender.tenant.config.NotificationSenderManagementConstants.ErrorMessage.ERROR_CODE_CHANNEL_TYPE_UPDATE_NOT_ALLOWED;
 import static org.wso2.carbon.identity.notification.sender.tenant.config.NotificationSenderManagementConstants.ErrorMessage.ERROR_CODE_CONFIGURATION_HANDLER_NOT_FOUND;
@@ -216,7 +217,7 @@ public class NotificationSenderManagementServiceImpl implements NotificationSend
         Resource resource = getPublisherResource(senderName).orElseThrow(() ->
                 new NotificationSenderManagementClientException(ERROR_CODE_PUBLISHER_NOT_EXISTS, senderName));
 
-        if (!canSenderDelete(senderName)) {
+        if (!StringUtils.equals(DEFAULT_SMS_PUBLISHER, senderName) && !canSenderDelete(senderName)) {
             throw new NotificationSenderManagementClientException(ERROR_CODE_CONNECTED_APPLICATION_EXISTS, senderName);
         }
 


### PR DESCRIPTION
### Purpose
- $subject
- With this validation current flow break when we try to update different types of sms providers (eg: default, choreo)

### Approach
- In the FE, we have specially handled the different type sms provider update as deleting the previous provider and creating a new provider. 
- With the above validation, we will not able to delete the provider when there are application which has sms-otp configured.
- With the removal of this validation we have improve the confirmation model message.

### Related PRs
- https://github.com/wso2/identity-apps/pull/7748

