### PR TITLE
Process utm parameters to be included in email templates

### DIFF
--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/NotificationConstants.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/NotificationConstants.java
@@ -48,10 +48,12 @@ public class NotificationConstants {
         public static final String OIDC_CLAIM_URI_EMAIL = "email";
         public static final String IDENTITY_CLAIM_PREFIX = "identity";
         public static final String USER_CLAIM_PREFIX = "user.claim";
+        public static final String UTM_PARAMETER_PREFIX = "utm_";
         public static final String IDENTITY_TEMPLATE_VALUE_PREFIX = "server.placeholder";
         public static final String TEMPLATE_PLACEHOLDERS_ELEM = "EmailTemplatePlaceholders";
         public static final String TEMPLATE_PLACEHOLDER_ELEM = "EmailTemplatePlaceholder";
         public static final String TEMPLATE_PLACEHOLDER_KEY_ATTRIB = "key";
+        public static final String UTM_PARAMETERS_PLACEHOLDER = "utm-parameters";
         public static final String WSO2_CLAIM_URI = "http://wso2.org/claims/";
 
         public static final String STREAM_NAME = "id_gov_notify_stream";

--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/util/NotificationUtil.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/util/NotificationUtil.java
@@ -301,25 +301,32 @@ public class NotificationUtil {
                             placeHolderData.put(placeHolder, "");
                         }
                     }
-                } else if (placeHolder.equals(NotificationConstants.EmailNotification.UTM_PARAMETERS_PLACEHOLDER)) {
-                    // Generate a single query param string with all UTM parameters
-                    StringBuilder utmParamStringBuilder = new StringBuilder();
-                    for (Map.Entry<String, String> entry : placeHolderData.entrySet()) {
-                        if (!entry.getKey().startsWith(
-                                NotificationConstants.EmailNotification.UTM_PARAMETER_PREFIX)) {
-                            continue;
-                        }
-                        utmParamStringBuilder.append("&").append(entry.getKey()).append("=").append(entry.getValue());
+                }
+            }
+            if (placeHolder.equals(NotificationConstants.EmailNotification.UTM_PARAMETERS_PLACEHOLDER)) {
+                // Generate a single query param string with all UTM parameters
+                StringBuilder utmParamStringBuilder = new StringBuilder();
+                for (Map.Entry<String, String> entry : placeHolderData.entrySet()) {
+                    if (!entry.getKey().startsWith(
+                            NotificationConstants.EmailNotification.UTM_PARAMETER_PREFIX)) {
+                        continue;
                     }
                     try {
-                        placeHolderData.put(NotificationConstants.EmailNotification.UTM_PARAMETERS_PLACEHOLDER,
-                                URLEncoder.encode(utmParamStringBuilder.toString(), StandardCharsets.UTF_8.toString()));
+                        String key = URLEncoder.encode(entry.getKey(), StandardCharsets.UTF_8.toString());
+                        String value = URLEncoder.encode(entry.getValue(), StandardCharsets.UTF_8.toString());
+                        if (utmParamStringBuilder.length() == 0) {
+                            utmParamStringBuilder.append(key).append("=").append(value);
+                        } else {
+                            utmParamStringBuilder.append("&").append(key).append("=").append(value);
+                        }
                     } catch (UnsupportedEncodingException e) {
-                        /* No need to break the flow for marketing parameter encoding errors. These values are for
-                        internal use only.*/
+                            /* No need to break the flow for marketing parameter encoding errors. These values are for
+                            internal use only.*/
                         log.warn("Error while encoding UTM parameters. Parameter values are ignored.", e);
                     }
                 }
+                placeHolderData.put(NotificationConstants.EmailNotification.UTM_PARAMETERS_PLACEHOLDER,
+                        utmParamStringBuilder.toString());
             }
         }
 

--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/util/NotificationUtil.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/util/NotificationUtil.java
@@ -309,14 +309,7 @@ public class NotificationUtil {
                                 NotificationConstants.EmailNotification.UTM_PARAMETER_PREFIX)) {
                             continue;
                         }
-                        if (utmParamStringBuilder.length() > 0) {
-                            utmParamStringBuilder.append("&");
-                        }
-                        utmParamStringBuilder.append(entry.getKey()).append("=")
-                                .append(entry.getValue());
-                    }
-                    if (utmParamStringBuilder.length() > 0) {
-                        utmParamStringBuilder.insert(0, "&");
+                        utmParamStringBuilder.append("&").append(entry.getKey()).append("=").append(entry.getValue());
                     }
                     try {
                         placeHolderData.put(NotificationConstants.EmailNotification.UTM_PARAMETERS_PLACEHOLDER,

--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/util/NotificationUtil.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/util/NotificationUtil.java
@@ -69,6 +69,9 @@ import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
 import org.wso2.carbon.user.core.service.RealmService;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
@@ -297,6 +300,31 @@ public class NotificationUtil {
                         if (placeHolderData.get(placeHolder) == null) {
                             placeHolderData.put(placeHolder, "");
                         }
+                    }
+                } else if (placeHolder.equals(NotificationConstants.EmailNotification.UTM_PARAMETERS_PLACEHOLDER)) {
+                    // Generate a single query param string with all UTM parameters
+                    StringBuilder utmParamStringBuilder = new StringBuilder();
+                    for (Map.Entry<String, String> entry : placeHolderData.entrySet()) {
+                        if (!entry.getKey().startsWith(
+                                NotificationConstants.EmailNotification.UTM_PARAMETER_PREFIX)) {
+                            continue;
+                        }
+                        if (utmParamStringBuilder.length() > 0) {
+                            utmParamStringBuilder.append("&");
+                        }
+                        utmParamStringBuilder.append(entry.getKey()).append("=")
+                                .append(entry.getValue());
+                    }
+                    if (utmParamStringBuilder.length() > 0) {
+                        utmParamStringBuilder.insert(0, "&");
+                    }
+                    try {
+                        placeHolderData.put(NotificationConstants.EmailNotification.UTM_PARAMETERS_PLACEHOLDER,
+                                URLEncoder.encode(utmParamStringBuilder.toString(), StandardCharsets.UTF_8.toString()));
+                    } catch (UnsupportedEncodingException e) {
+                        /* No need to break the flow for marketing parameter encoding errors. These values are for
+                        internal use only.*/
+                        log.warn("Error while encoding UTM parameters. Parameter values are ignored.", e);
                     }
                 }
             }

--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/test/java/org/wso2/carbon/identity/event/handler/notification/util/NotificationUtilTest.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/test/java/org/wso2/carbon/identity/event/handler/notification/util/NotificationUtilTest.java
@@ -55,8 +55,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyMap;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
@@ -400,9 +398,9 @@ public class NotificationUtilTest {
     }
 
     @Test(dataProvider = "GetPlaceholderValuesDataProvider")
-    public void testGetPlaceHolderValues(EmailTemplate emailTemplate,
-                                         Map<String, String> placeHolderData,
-                                         Map<String, String> userClaims, String applicationUuid) {
+    public void testGetPlaceHolderValues(EmailTemplate emailTemplate, Map<String, String> placeHolderData,
+                                         Map<String, String> userClaims, String applicationUuid)
+            throws URLBuilderException {
 
         try (
                 MockedStatic<IdentityConfigParser> staticMockedIdentityConfigParser =
@@ -439,8 +437,6 @@ public class NotificationUtilTest {
                     UTM_PARAMETER_PREFIX + "campaign" + "=" + "UTM_CAMPAIGN_SAMPLE" + "&" +
                             UTM_PARAMETER_PREFIX + "medium" + "=" + "UTM_MEDIUM_SAMPLE" + "&" +
                                     UTM_PARAMETER_PREFIX + "source" + "=" + "UTM_SOURCE_SAMPLE");
-        } catch (URLBuilderException e) {
-            throw new RuntimeException(e);
         }
     }
 

--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/test/java/org/wso2/carbon/identity/event/handler/notification/util/NotificationUtilTest.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/test/java/org/wso2/carbon/identity/event/handler/notification/util/NotificationUtilTest.java
@@ -28,6 +28,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
+import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -37,8 +38,12 @@ import org.wso2.carbon.email.mgt.constants.I18nMgtConstants;
 import org.wso2.carbon.email.mgt.exceptions.I18nEmailMgtException;
 import org.wso2.carbon.email.mgt.model.EmailTemplate;
 import org.wso2.carbon.identity.application.authentication.framework.config.ConfigurationFacade;
+import org.wso2.carbon.identity.core.ServiceURL;
+import org.wso2.carbon.identity.core.ServiceURLBuilder;
+import org.wso2.carbon.identity.core.URLBuilderException;
 import org.wso2.carbon.identity.core.internal.IdentityCoreServiceComponent;
 import org.wso2.carbon.identity.core.util.IdentityConfigParser;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.event.IdentityEventConstants;
 import org.wso2.carbon.identity.event.event.Event;
 import org.wso2.carbon.identity.event.handler.notification.NotificationConstants;
@@ -50,12 +55,16 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static org.testng.Assert.assertEquals;
 import static org.wso2.carbon.identity.event.handler.notification.NotificationConstants.EmailNotification.ORGANIZATION_NAME_PLACEHOLDER;
+import static org.wso2.carbon.identity.event.handler.notification.NotificationConstants.EmailNotification.UTM_PARAMETERS_PLACEHOLDER;
+import static org.wso2.carbon.identity.event.handler.notification.NotificationConstants.EmailNotification.UTM_PARAMETER_PREFIX;
 
 /**
  * Class that contains the test cases for NotificationUtil class.
@@ -223,6 +232,31 @@ public class NotificationUtilTest {
         };
     }
 
+    @DataProvider(name = "GetPlaceholderValuesDataProvider")
+    public Object[][] providePlaceholderValuesTestData() {
+
+        EmailTemplate emailTemplate = new EmailTemplate();
+        emailTemplate.setSubject("Sample Subject");
+        emailTemplate.setBody("Test email body. UTM Parameter query string : {{" + UTM_PARAMETERS_PLACEHOLDER + "}}.");
+        emailTemplate.setFooter("Sample Footer");
+        emailTemplate.setLocale("en_US");
+        emailTemplate.setTemplateType("liteuseremailconfirmation");
+        emailTemplate.setTemplateDisplayName("liteuseremailconfirmation");
+
+
+        Map<String, String> placeHolderData = new HashMap<>();
+        placeHolderData.put(UTM_PARAMETER_PREFIX + "source", "UTM_SOURCE_SAMPLE");
+        placeHolderData.put(UTM_PARAMETER_PREFIX + "medium", "UTM_MEDIUM_SAMPLE");
+        placeHolderData.put(UTM_PARAMETER_PREFIX + "campaign", "UTM_CAMPAIGN_SAMPLE");
+        placeHolderData.put("random-placeholder", "random-value");
+
+        Map<String, String> userClaims = new HashMap<>();
+
+        return new Object[][] {
+                {emailTemplate, placeHolderData, userClaims, null}
+        };
+    }
+
     @Test(dataProvider = "GetBrandingPreferenceDataProvider")
     public void testGetBrandingPreference(JsonNode brandingPreferences, Map<String, String> brandingFallback, int caseNo) {
 
@@ -362,6 +396,51 @@ public class NotificationUtilTest {
             } else {
                 assertEquals(I18nMgtConstants.DEFAULT_NOTIFICATION_LOCALE, capturedLocale);
             }
+        }
+    }
+
+    @Test(dataProvider = "GetPlaceholderValuesDataProvider")
+    public void testGetPlaceHolderValues(EmailTemplate emailTemplate,
+                                         Map<String, String> placeHolderData,
+                                         Map<String, String> userClaims, String applicationUuid) {
+
+        try (
+                MockedStatic<IdentityConfigParser> staticMockedIdentityConfigParser =
+                        Mockito.mockStatic(IdentityConfigParser.class);
+                MockedStatic<IdentityUtil> staticMockedIdentityUtil = Mockito.mockStatic(IdentityUtil.class);
+                MockedStatic<ConfigurationFacade> staticMockedConfigurationFacade =
+                        Mockito.mockStatic(ConfigurationFacade.class);
+                MockedStatic<ServiceURLBuilder> staticMockedServiceURLBuilder =
+                        Mockito.mockStatic(ServiceURLBuilder.class);
+        ) {
+            IdentityConfigParser mockedIdentityConfigParser = mock(IdentityConfigParser.class);
+            when(mockedIdentityConfigParser.getConfigElement(
+                    NotificationConstants.EmailNotification.ORGANIZATION_LEVEL_EMAIL_BRANDING_FALLBACKS_ELEM))
+                    .thenReturn(null);
+
+            staticMockedIdentityConfigParser.when(IdentityConfigParser::getInstance)
+                    .thenReturn(mockedIdentityConfigParser);
+            staticMockedIdentityUtil.when(() -> IdentityUtil.getProperty(
+                    NotificationConstants.EmailNotification.ENABLE_ORGANIZATION_LEVEL_EMAIL_BRANDING))
+                    .thenReturn("false");
+
+            staticMockedConfigurationFacade.when(ConfigurationFacade::getInstance)
+                    .thenReturn(mock(ConfigurationFacade.class));
+
+            ServiceURL serviceURL = mock(ServiceURL.class);
+            when(serviceURL.getAbsolutePublicURL()).thenReturn("https://wso2test.com");
+            ServiceURLBuilder mockedServiceURLBuilder = mock(ServiceURLBuilder.class);
+            when(mockedServiceURLBuilder.build()).thenReturn(serviceURL);
+            staticMockedServiceURLBuilder.when(ServiceURLBuilder::create).thenReturn(mockedServiceURLBuilder);
+
+            NotificationUtil.getPlaceholderValues(emailTemplate, placeHolderData, userClaims, applicationUuid);
+            Assert.assertNotNull(placeHolderData.get(UTM_PARAMETERS_PLACEHOLDER));
+            Assert.assertEquals(placeHolderData.get(UTM_PARAMETERS_PLACEHOLDER),
+                    UTM_PARAMETER_PREFIX + "campaign" + "=" + "UTM_CAMPAIGN_SAMPLE" + "&" +
+                            UTM_PARAMETER_PREFIX + "medium" + "=" + "UTM_MEDIUM_SAMPLE" + "&" +
+                                    UTM_PARAMETER_PREFIX + "source" + "=" + "UTM_SOURCE_SAMPLE");
+        } catch (URLBuilderException e) {
+            throw new RuntimeException(e);
         }
     }
 


### PR DESCRIPTION
### Propose
As part of he feature to support UTM parameter tracking, this PR introduces the improvements to process and include the utm parameter values in the email templates. 

### Description
This pull request introduces support for handling UTM parameters in email notifications by adding new constants and logic to generate and encode UTM parameter strings. The changes ensure that UTM parameters can be dynamically included in email templates while maintaining proper encoding.

#### Enhancements to Email Notification Handling:

* **New Constants for UTM Parameters**: Added `UTM_PARAMETER_PREFIX` and `UTM_PARAMETERS_PLACEHOLDER` constants in `NotificationConstants` to define placeholders for UTM parameters in email templates.

* **UTM Parameter Encoding Logic**: Updated the `getPlaceholderValues` method in `NotificationUtil` to dynamically generate and encode a query string for UTM parameters. This ensures proper formatting and encoding of UTM parameters for use in email templates.

#### Supporting Changes:

* **Imports for Encoding**: Added imports for `URLEncoder`, `UnsupportedEncodingException`, and `StandardCharsets` in `NotificationUtil` to support the encoding of UTM parameters.

### Related PR/s
- https://github.com/wso2-extensions/identity-governance/pull/951