### PR TITLE
Prepend & sign to utm-parameter query

### DIFF
--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/util/NotificationUtil.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/util/NotificationUtil.java
@@ -314,11 +314,7 @@ public class NotificationUtil {
                     try {
                         String key = URLEncoder.encode(entry.getKey(), StandardCharsets.UTF_8.toString());
                         String value = URLEncoder.encode(entry.getValue(), StandardCharsets.UTF_8.toString());
-                        if (utmParamStringBuilder.length() == 0) {
-                            utmParamStringBuilder.append(key).append("=").append(value);
-                        } else {
-                            utmParamStringBuilder.append("&").append(key).append("=").append(value);
-                        }
+                        utmParamStringBuilder.append("&").append(key).append("=").append(value);
                     } catch (UnsupportedEncodingException e) {
                             /* No need to break the flow for marketing parameter encoding errors. These values are for
                             internal use only.*/

--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/test/java/org/wso2/carbon/identity/event/handler/notification/util/NotificationUtilTest.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/test/java/org/wso2/carbon/identity/event/handler/notification/util/NotificationUtilTest.java
@@ -434,9 +434,9 @@ public class NotificationUtilTest {
             NotificationUtil.getPlaceholderValues(emailTemplate, placeHolderData, userClaims, applicationUuid);
             Assert.assertNotNull(placeHolderData.get(UTM_PARAMETERS_PLACEHOLDER));
             Assert.assertEquals(placeHolderData.get(UTM_PARAMETERS_PLACEHOLDER),
-                    UTM_PARAMETER_PREFIX + "campaign" + "=" + "UTM_CAMPAIGN_SAMPLE" + "&" +
-                            UTM_PARAMETER_PREFIX + "medium" + "=" + "UTM_MEDIUM_SAMPLE" + "&" +
-                                    UTM_PARAMETER_PREFIX + "source" + "=" + "UTM_SOURCE_SAMPLE");
+                    "&" + UTM_PARAMETER_PREFIX + "campaign" + "=" + "UTM_CAMPAIGN_SAMPLE" +
+                    "&" + UTM_PARAMETER_PREFIX + "medium" + "=" + "UTM_MEDIUM_SAMPLE" +
+                    "&" + UTM_PARAMETER_PREFIX + "source" + "=" + "UTM_SOURCE_SAMPLE");
         }
     }
 


### PR DESCRIPTION
### Propose
utm-poarameter placeholder for email templates currently builds a query string without a '&' sign at the begining. However since there's a chance this query can be empty if no utm-params are used, we have to include the & sing in the query itself to not be included when not utm parameters are present. (Otherwise this has to be hardcoded to email template and cannot be excluded when utm-parameters are not present.)

### Summary
This pull request refines the handling of UTM parameter encoding in the `NotificationUtil` class and adjusts the corresponding test cases to reflect the updated behavior. The changes ensure that UTM parameters are consistently prefixed with an ampersand (`&`), even for the first parameter, simplifying the logic.

#### Changes to UTM parameter handling:

* [`NotificationUtil.java`](diffhunk://#diff-b23736d56ae4607fa17969813f188e12ee03bbec349b176d734a349358bf6b9cL317-L321): Removed conditional logic that treated the first UTM parameter differently, ensuring all parameters are uniformly prefixed with `&`. This simplifies the string-building process for UTM parameters.

#### Updates to test cases:

* [`NotificationUtilTest.java`](diffhunk://#diff-be0be7727107239e43c5bd183504713ad40adafd024eb4cc6df0b9289b201b88L437-R439): Updated the test case for `getPlaceholderValues` to reflect the new behavior, where UTM parameters always include an initial `&` prefix. This ensures the test aligns with the updated implementation.

### Related PR/s
- https://github.com/wso2-extensions/identity-event-handler-notification/pull/323