### PR TITLE
Allow resending code in SMS account confirmation flow

### DIFF
--- a/features/org.wso2.carbon.email.mgt.server.feature/resources/sms-templates-admin-config.xml
+++ b/features/org.wso2.carbon.email.mgt.server.feature/resources/sms-templates-admin-config.xml
@@ -35,6 +35,9 @@
     <configuration type="passwordReset" display="passwordReset" locale="en_US">
         <body>Your One-Time Password : {{confirmation-code}}</body>
     </configuration>
+    <configuration type="resendaccountconfirmation" display="resendaccountconfirmation" locale="en_US">
+        <body>Your One-Time Password : {{confirmation-code}}</body>
+    </configuration>
     <configuration type="resendPasswordReset" display="resendPasswordReset" locale="en_US">
         <body>Your One-Time Password : {{confirmation-code}}</body>
     </configuration>


### PR DESCRIPTION
## Purpose
Add the missing template for resending sms OTP for account confirmation scenarions.

## Implementation
Add a new template for resending account confirmation.

## Related Issues
- [Public] https://github.com/wso2/product-is/issues/23583
