### PR TITLE
[1.7.x] Change the findsecbugs-plugin version to 1.12.0

### DIFF
--- a/components/notification-sender-config/org.wso2.carbon.identity.notification.sender.tenant.config/pom.xml
+++ b/components/notification-sender-config/org.wso2.carbon.identity.notification.sender.tenant.config/pom.xml
@@ -137,7 +137,7 @@
                         <plugin>
                             <groupId>com.h3xstream.findsecbugs</groupId>
                             <artifactId>findsecbugs-plugin</artifactId>
-                            <version>LATEST</version> <!-- Auto-update to the latest stable -->
+                            <version>${findsecbugs-plugin.version}</version>
                         </plugin>
                     </plugins>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -454,6 +454,7 @@
         <apache.felix.scr.ds.annotations.version>1.2.4</apache.felix.scr.ds.annotations.version>
         <maven.checkstyleplugin.version>2.17</maven.checkstyleplugin.version>
         <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
+        <findsecbugs-plugin.version>1.12.0</findsecbugs-plugin.version>
         <mavan.findbugsplugin.exclude.file>findbugs-exclude-filter.xml</mavan.findbugsplugin.exclude.file>
 
         <com.fasterxml.jackson.databind.version>2.13.3</com.fasterxml.jackson.databind.version>


### PR DESCRIPTION
### Proposed changes in this pull request

This PR changes the findsecbugs plugin version to 1.12.0 to support with the findbugs plugin version.