### PR TITLE
Fix consistency issue in Email Template's org name in carbon.super tenant

### DIFF
--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/pom.xml
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/pom.xml
@@ -205,6 +205,7 @@
                             org.wso2.carbon.identity.organization.management.service;version="${org.wso2.identity.organization.mgt.core.imp.pkg.version.range}",
                             org.wso2.carbon.identity.organization.management.service.constant;version="${org.wso2.identity.organization.mgt.core.imp.pkg.version.range}",
                             org.wso2.carbon.identity.organization.management.service.exception;version="${org.wso2.identity.organization.mgt.core.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.organization.management.service.util;version="${org.wso2.identity.organization.mgt.core.imp.pkg.version.range}",
                             org.wso2.carbon.identity.notification.push.provider; version="${identity.notification.push.version.range}",
                             org.wso2.carbon.identity.notification.push.provider.exception; version="${identity.notification.push.version.range}",
                             org.wso2.carbon.identity.notification.push.provider.model; version="${identity.notification.push.version.range}",

--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/util/NotificationUtil.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/util/NotificationUtil.java
@@ -63,6 +63,8 @@ import org.wso2.carbon.identity.governance.model.UserIdentityClaim;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementClientException;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
+import org.wso2.carbon.identity.organization.management.service.util.OrganizationManagementUtil;
+import org.wso2.carbon.identity.organization.management.service.util.Utils;
 import org.wso2.carbon.user.api.Claim;
 import org.wso2.carbon.user.api.Tenant;
 import org.wso2.carbon.user.api.UserStoreException;
@@ -839,6 +841,9 @@ public class NotificationUtil {
         String organizationName = tenantDomain;
         try {
             if (SUPER_TENANT_DOMAIN_NAME.equals(tenantDomain)) {
+                if (Utils.isSuperOrgNameSupportedInNotificationTemplates()) {
+                    return OrganizationManagementUtil.getSuperRootOrgName();
+                }
                 return organizationName;
             }
             RealmService realmService = NotificationHandlerDataHolder.getInstance().getRealmService();

--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/test/java/org/wso2/carbon/identity/event/handler/notification/PushNotificationHandlerTest.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/test/java/org/wso2/carbon/identity/event/handler/notification/PushNotificationHandlerTest.java
@@ -30,6 +30,7 @@ import org.wso2.carbon.identity.event.IdentityEventException;
 import org.wso2.carbon.identity.event.bean.IdentityEventMessageContext;
 import org.wso2.carbon.identity.event.event.Event;
 import org.wso2.carbon.identity.event.handler.notification.internal.NotificationHandlerDataHolder;
+import org.wso2.carbon.identity.event.handler.notification.util.NotificationUtil;
 import org.wso2.carbon.identity.notification.push.provider.PushProvider;
 import org.wso2.carbon.identity.notification.push.provider.exception.PushProviderException;
 import org.wso2.carbon.identity.notification.push.provider.model.PushNotificationData;
@@ -54,6 +55,8 @@ import static org.mockito.Mockito.when;
  * Test class for PushNotificationHandler.
  */
 public class PushNotificationHandlerTest {
+
+    private static final String SAMPLE_ORGANIZATION_NAME = "Great Hospital";
 
     @InjectMocks
     private PushNotificationHandler pushNotificationHandler;
@@ -104,9 +107,12 @@ public class PushNotificationHandlerTest {
         event.getEventProperties().put("user-name", "sampleUser");
 
         try (MockedStatic<NotificationHandlerDataHolder> mockedDataHolder = mockStatic(
-                NotificationHandlerDataHolder.class)) {
+                NotificationHandlerDataHolder.class);
+             MockedStatic<NotificationUtil> mockedNotificationUtil = mockStatic(NotificationUtil.class)) {
 
             mockedDataHolder.when(NotificationHandlerDataHolder::getInstance).thenReturn(notificationHandlerDataHolder);
+            mockedNotificationUtil.when(() -> NotificationUtil.resolveHumanReadableOrganizationName(anyString()))
+                    .thenReturn(SAMPLE_ORGANIZATION_NAME);
             when(notificationHandlerDataHolder.getOrganizationManager()).thenReturn(organizationManager);
             when(organizationManager.resolveOrganizationId(anyString())).thenReturn("orgId");
             when(notificationHandlerDataHolder.getNotificationSenderManagementService()).thenReturn(
@@ -247,9 +253,12 @@ public class PushNotificationHandlerTest {
         event.getEventProperties().put("user-name", "sampleUser");
 
         try (MockedStatic<NotificationHandlerDataHolder> mockedDataHolder = mockStatic(
-                NotificationHandlerDataHolder.class)) {
+                NotificationHandlerDataHolder.class);
+             MockedStatic<NotificationUtil> mockedNotificationUtil = mockStatic(NotificationUtil.class)) {
 
             mockedDataHolder.when(NotificationHandlerDataHolder::getInstance).thenReturn(notificationHandlerDataHolder);
+            mockedNotificationUtil.when(() -> NotificationUtil.resolveHumanReadableOrganizationName(anyString()))
+                    .thenReturn(SAMPLE_ORGANIZATION_NAME);
             when(notificationHandlerDataHolder.getOrganizationManager()).thenReturn(organizationManager);
             when(organizationManager.resolveOrganizationId(anyString())).thenReturn("orgId");
             when(notificationHandlerDataHolder.getNotificationSenderManagementService()).thenReturn(

--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/test/java/org/wso2/carbon/identity/event/handler/notification/util/NotificationUtilTest.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/test/java/org/wso2/carbon/identity/event/handler/notification/util/NotificationUtilTest.java
@@ -48,6 +48,8 @@ import org.wso2.carbon.identity.event.IdentityEventConstants;
 import org.wso2.carbon.identity.event.event.Event;
 import org.wso2.carbon.identity.event.handler.notification.NotificationConstants;
 import org.wso2.carbon.identity.event.handler.notification.internal.NotificationHandlerDataHolder;
+import org.wso2.carbon.identity.organization.management.service.util.OrganizationManagementUtil;
+import org.wso2.carbon.identity.organization.management.service.util.Utils;
 import org.wso2.carbon.utils.CarbonUtils;
 import org.wso2.carbon.utils.ConfigurationContextService;
 
@@ -63,6 +65,8 @@ import static org.testng.Assert.assertEquals;
 import static org.wso2.carbon.identity.event.handler.notification.NotificationConstants.EmailNotification.ORGANIZATION_NAME_PLACEHOLDER;
 import static org.wso2.carbon.identity.event.handler.notification.NotificationConstants.EmailNotification.UTM_PARAMETERS_PLACEHOLDER;
 import static org.wso2.carbon.identity.event.handler.notification.NotificationConstants.EmailNotification.UTM_PARAMETER_PREFIX;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.SUPER;
+import static org.wso2.carbon.utils.multitenancy.MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
 
 /**
  * Class that contains the test cases for NotificationUtil class.
@@ -438,6 +442,33 @@ public class NotificationUtilTest {
                     "&" + UTM_PARAMETER_PREFIX + "campaign" + "=" + "UTM_CAMPAIGN_SAMPLE" +
                     "&" + UTM_PARAMETER_PREFIX + "medium" + "=" + "UTM_MEDIUM_SAMPLE" +
                     "&" + UTM_PARAMETER_PREFIX + "source" + "=" + "UTM_SOURCE_SAMPLE");
+        }
+    }
+
+    @DataProvider(name = "resolveSuperTenantOrganizationNameDataProvider")
+    public Object[][] resolveSuperTenantOrganizationNameDataProvider() {
+
+        return new Object[][] {
+                {true, SUPER},
+                {false, SUPER_TENANT_DOMAIN_NAME}
+        };
+    }
+
+    @Test(dataProvider = "resolveSuperTenantOrganizationNameDataProvider")
+    public void testResolveHumanReadableOrganizationNameForSuperTenant(boolean isSuperOrgNameSupported,
+                                                                       String expectedOrgName)
+            throws Exception {
+
+        try (MockedStatic<Utils> mockedUtils = mockStatic(Utils.class);
+             MockedStatic<OrganizationManagementUtil> mockedOrgManagementUtil = mockStatic(
+                     OrganizationManagementUtil.class)) {
+
+            mockedUtils.when(Utils::isSuperOrgNameSupportedInNotificationTemplates)
+                    .thenReturn(isSuperOrgNameSupported);
+            mockedOrgManagementUtil.when(OrganizationManagementUtil::getSuperRootOrgName).thenReturn(expectedOrgName);
+
+            String result = NotificationUtil.resolveHumanReadableOrganizationName(SUPER_TENANT_DOMAIN_NAME);
+            assertEquals(result, expectedOrgName);
         }
     }
 

--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/test/java/org/wso2/carbon/identity/event/handler/notification/util/NotificationUtilTest.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/test/java/org/wso2/carbon/identity/event/handler/notification/util/NotificationUtilTest.java
@@ -167,7 +167,6 @@ public class NotificationUtilTest {
 
         String brandingPreferencesStr = "{" +
                 "\"configs\":{\"isBrandingEnabled\":%s}," +
-                "\"urls\": {\"recoveryPortalURL\":\"%s\"}," +
                 "\"organizationDetails\":{\"copyrightText\":\"%s\",\"supportEmail\":\"%s\"}," +
                 "\"theme\":{\"activeTheme\":\"%s\"," +
                 "\"LIGHT\":{\"buttons\":{\"primary\":{\"base\":{\"font\":{\"color\":\"%s\"}}}}," +
@@ -187,7 +186,7 @@ public class NotificationUtilTest {
                 ORGANIZATION_DARK_LOGO_ALT_TEXT, ORGANIZATION_DARK_LOGO_URL, ORGANIZATION_DARK_BACKGROUND_COLOR,
                 ORGANIZATION_DARK_FONT_COLOR, ORGANIZATION_DARK_FONT);
         String brandingPreferencesStr2 = String.format(brandingPreferencesStr,
-                BRANDING_ENABLED, "", ORGANIZATION_COPYRIGHT_TEXT, ORGANIZATION_SUPPORT_EMAIL, DARK_THEME,
+                BRANDING_ENABLED, ORGANIZATION_COPYRIGHT_TEXT, ORGANIZATION_SUPPORT_EMAIL, DARK_THEME,
                 ORGANIZATION_LIGHT_BUTTON_FONT_COLOR, ORGANIZATION_LIGHT_PRIMARY_COLOR, ORGANIZATION_LIGHT_LOGO_ALT_TEXT,
                 ORGANIZATION_LIGHT_LOGO_URL, ORGANIZATION_LIGHT_BACKGROUND_COLOR, ORGANIZATION_LIGHT_FONT_COLOR,
                 ORGANIZATION_LIGHT_FONT, ORGANIZATION_DARK_BUTTON_FONT_COLOR, ORGANIZATION_DARK_PRIMARY_COLOR,

--- a/pom.xml
+++ b/pom.xml
@@ -538,7 +538,7 @@
         <axis2.osgi.version.range>[1.6.1, 2.0.0)</axis2.osgi.version.range>
 
         <!--Carbon Commons Version-->
-        <carbon.commons.version>4.7.11</carbon.commons.version>
+        <carbon.commons.version>4.10.24</carbon.commons.version>
         <carbon.commons.imp.pkg.version>[4.7.11, 5.0.0)</carbon.commons.imp.pkg.version>
 
         <!--Carbon Database Utils Version-->

--- a/pom.xml
+++ b/pom.xml
@@ -550,7 +550,7 @@
         <carbon.identity.framework.imp.pkg.version.range>[7.1.0, 8.0.0)</carbon.identity.framework.imp.pkg.version.range>
 
         <!-- Organization management Version -->
-        <identity.organization.management.core.version>1.0.93</identity.organization.management.core.version>
+        <identity.organization.management.core.version>1.1.55</identity.organization.management.core.version>
         <org.wso2.identity.organization.mgt.core.imp.pkg.version.range>[1.0.0,2.0.0)
         </org.wso2.identity.organization.mgt.core.imp.pkg.version.range>
         <identity.organization.management.version>2.0.0</identity.organization.management.version>


### PR DESCRIPTION
## Purpose
$subject

This will send the actual super organization name instead of "carbon.super" in email templates.

Issues: https://github.com/wso2/product-is/issues/25378

Related PRs: https://github.com/wso2/identity-organization-management-core/pull/207