### PR TITLE
Update email and SMS templates to align with invited user registration

### DIFF
--- a/features/org.wso2.carbon.email.mgt.server.feature/resources/email-admin-config.xml
+++ b/features/org.wso2.carbon.email.mgt.server.feature/resources/email-admin-config.xml
@@ -7258,7 +7258,7 @@
                                                                                         username in the organization
                                                                                         <b>{{organization-name}}</b>.<br>
                                                                                         Username: <b>{{user-name}}</b><br><br>
-                                                                                        Please use this one-time password (OTP) to verify your account and complete your registration.<br>
+                                                                                        Please use this one-time password (OTP) to signin and complete your registration.<br>
                                                                                     </p>
                                                                                     <p style="font-family: '{{organization.font}}', Roboto, Verdana, Helvetica, sans-serif;
                                                                                         font-size: 24px;
@@ -7714,7 +7714,7 @@
                                                                                         username in the organization
                                                                                         <b>{{organization-name}}</b>.<br>
                                                                                         Username: <b>{{user-name}}</b><br><br>
-                                                                                        Please use this one-time password (OTP) to verify your account and complete your registration.<br>
+                                                                                        Please use this one-time password (OTP) to signin and complete your registration.<br>
                                                                                     </p>
                                                                                     <p style="font-family: '{{organization.font}}', Roboto, Verdana, Helvetica, sans-serif;
                                                                                         font-size: 24px;

--- a/features/org.wso2.carbon.email.mgt.server.feature/resources/sms-templates-admin-config.xml
+++ b/features/org.wso2.carbon.email.mgt.server.feature/resources/sms-templates-admin-config.xml
@@ -57,10 +57,10 @@
         <body>Please use code {{confirmation-code}} to verify your mobile and continue registration with {{organization-name}}.</body>
     </configuration>
     <configuration type="askPasswordSMSOTP" display="askPasswordSMSOTP" locale="en_US">
-        <body>Please use this one-time password (OTP): {{confirmation-code}} to verify your account and complete your registration.</body>
+        <body>Please use this one-time password (OTP): {{confirmation-code}} to signin and complete your registration.</body>
     </configuration>
     <configuration type="askPasswordResendSMSOTP" display="askPasswordResendSMSOTP" locale="en_US">
-        <body>Please use this one-time password (OTP): {{confirmation-code}} to verify your account and complete your registration.</body>
+        <body>Please use this one-time password (OTP): {{confirmation-code}} to signin and complete your registration.</body>
     </configuration>
     <configuration type="askPasswordSetSuccess" display="askPasswordSetSuccess" locale="en_US">
         <body>Your account has been set up successfully.</body>


### PR DESCRIPTION
### Proposed changes in this pull request
$subject

### Related Issues
- https://github.com/wso2/product-is/issues/25650


### Email send and resend


<img width="631" height="680" alt="Screenshot 2025-09-15 at 07 16 28" src="https://github.com/user-attachments/assets/c27ab54d-287a-44b9-9a15-22d39902f710" />

### SMS send and resend


<img width="950" height="116" alt="Screenshot 2025-09-15 at 07 30 48" src="https://github.com/user-attachments/assets/0b9dbcfa-6160-46ff-8504-fcc6b6835136" />
