### PR TITLE
Fix tenant and sub-organization differentiation logic when building the PushNotificationData in push notification handler

### DIFF
--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/PushNotificationHandler.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/PushNotificationHandler.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.identity.event.handler.notification;
 
 import org.apache.commons.lang.StringUtils;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.base.IdentityRuntimeException;
 import org.wso2.carbon.identity.core.bean.context.MessageContext;
 import org.wso2.carbon.identity.event.IdentityEventConstants;
@@ -267,10 +268,31 @@ public class PushNotificationHandler extends DefaultNotificationHandler {
         }
 
         String organizationId = null;
+        String primaryTenantDomain = null;
+
         if (NotificationUtil.isOrganization(tenantDomain)) {
-            organizationId = NotificationUtil.getOrganizationUUID(tenantDomain);
+            LOG.debug("Tenant domain is an organization.");
+            try {
+                organizationId = NotificationHandlerDataHolder.getInstance()
+                        .getOrganizationManager().resolveOrganizationId(tenantDomain);
+            } catch (OrganizationManagementException e) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Error while resolving organization ID for tenant domain: " + tenantDomain, e);
+                }
+                throw new IdentityEventException(e.getMessage(), e);
+            }
+
+            /* If an accessing organization ID is present, this flow is for a tenant organization path
+             * (/t/{tenant-domain}/o/{org-id}).
+             * Therefore, include the primary tenant domain in the PushNotificationData. */
+            if (StringUtils.isNotEmpty(PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                    .getAccessingOrganizationId())) {
+                LOG.debug("Adding primary tenant domain to the push notification data.");
+                primaryTenantDomain = NotificationUtil.getPrimaryTenantDomain(organizationId);
+            }
         } else {
             // If tenant user, organizationName is null.
+            LOG.debug("Tenant domain is not an organization.");
             organizationName = null;
         }
 
@@ -285,6 +307,7 @@ public class PushNotificationHandler extends DefaultNotificationHandler {
                 .setTenantDomain(tenantDomain)
                 .setOrganizationId(organizationId)
                 .setOrganizationName(organizationName)
+                .setPrimaryTenantDomain(primaryTenantDomain)
                 .setUserStoreDomain((String) eventProperties.get(
                         IdentityEventConstants.EventProperty.USER_STORE_DOMAIN))
                 .setApplicationName((String) eventProperties.get(IdentityEventConstants.EventProperty.APPLICATION_NAME))

--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/PushNotificationHandler.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/PushNotificationHandler.java
@@ -266,13 +266,9 @@ public class PushNotificationHandler extends DefaultNotificationHandler {
             placeholderValues.put(ORGANIZATION_NAME_PLACEHOLDER, organizationName);
         }
 
-        /*
-         * If the tenant domain is different from the organization name, then it is an organization user. Hence,
-         * the organization ID is the tenant domain.
-         */
         String organizationId = null;
-        if (!tenantDomain.equals(organizationName)) {
-            organizationId = tenantDomain;
+        if (NotificationUtil.isOrganization(tenantDomain)) {
+            organizationId = NotificationUtil.getOrganizationUUID(tenantDomain);
         } else {
             // If tenant user, organizationName is null.
             organizationName = null;

--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/util/NotificationUtil.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/util/NotificationUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2024, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2016-2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except
@@ -867,6 +867,46 @@ public class NotificationUtil {
             throw new IdentityEventException(e.getMessage(), e);
         }
         return organizationName;
+    }
+
+    /**
+     * Check whether the given tenant domain belongs to an organization.
+     *
+     * @param tenetDomain Tenant domain.
+     * @return true if the tenant domain belongs to an organization, false otherwise.
+     * @throws IdentityEventException Error while checking whether the tenant domain belongs to an organization.
+     */
+    public static boolean isOrganization(String tenetDomain) throws IdentityEventException {
+
+        try {
+            return OrganizationManagementUtil.isOrganization(tenetDomain);
+        } catch (OrganizationManagementException e) {
+            throw new IdentityEventException(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Get the organization UUID for the given tenant domain.
+     *
+     * @param tenantDomain Tenant domain.
+     * @return Organization UUID for the given tenant domain, or null if the tenant domain does not belong to an organization.
+     * @throws IdentityEventException Error while retrieving the organization UUID for the given tenant domain.
+     */
+    public static String getOrganizationUUID(String tenantDomain) throws IdentityEventException {
+
+        String organizationUUID = null;
+        try {
+            RealmService realmService = NotificationHandlerDataHolder.getInstance().getRealmService();
+            int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
+            Tenant tenant = realmService.getTenantManager().getTenant(tenantId);
+            if (tenant == null) {
+                return null;
+            }
+            organizationUUID = tenant.getAssociatedOrganizationUUID();
+        } catch (UserStoreException e) {
+            throw new IdentityEventException(e.getMessage(), e);
+        }
+        return organizationUUID;
     }
 
     /**

--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/util/NotificationUtil.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/util/NotificationUtil.java
@@ -872,14 +872,14 @@ public class NotificationUtil {
     /**
      * Check whether the given tenant domain belongs to an organization.
      *
-     * @param tenetDomain Tenant domain.
+     * @param tenantDomain Tenant domain.
      * @return true if the tenant domain belongs to an organization, false otherwise.
      * @throws IdentityEventException Error while checking whether the tenant domain belongs to an organization.
      */
-    public static boolean isOrganization(String tenetDomain) throws IdentityEventException {
+    public static boolean isOrganization(String tenantDomain) throws IdentityEventException {
 
         try {
-            return OrganizationManagementUtil.isOrganization(tenetDomain);
+            return OrganizationManagementUtil.isOrganization(tenantDomain);
         } catch (OrganizationManagementException e) {
             throw new IdentityEventException(e.getMessage(), e);
         }

--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/util/NotificationUtil.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/util/NotificationUtil.java
@@ -886,27 +886,22 @@ public class NotificationUtil {
     }
 
     /**
-     * Get the organization UUID for the given tenant domain.
+     * Get the primary tenant domain of the given organization ID.
      *
-     * @param tenantDomain Tenant domain.
-     * @return Organization UUID for the given tenant domain, or null if the tenant domain does not belong to an organization.
-     * @throws IdentityEventException Error while retrieving the organization UUID for the given tenant domain.
+     * @param organizationId Organization ID.
+     * @return Primary tenant domain.
+     * @throws IdentityEventException If an error occurred while getting the primary tenant domain.
      */
-    public static String getOrganizationUUID(String tenantDomain) throws IdentityEventException {
+    public static String getPrimaryTenantDomain(String organizationId) throws IdentityEventException {
 
-        String organizationUUID = null;
         try {
-            RealmService realmService = NotificationHandlerDataHolder.getInstance().getRealmService();
-            int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
-            Tenant tenant = realmService.getTenantManager().getTenant(tenantId);
-            if (tenant == null) {
-                return null;
-            }
-            organizationUUID = tenant.getAssociatedOrganizationUUID();
-        } catch (UserStoreException e) {
+            OrganizationManager organizationManager = NotificationHandlerDataHolder.getInstance()
+                    .getOrganizationManager();
+            String primaryOrgId = organizationManager.getPrimaryOrganizationId(organizationId);
+            return organizationManager.resolveTenantDomain(primaryOrgId);
+        } catch (OrganizationManagementException e) {
             throw new IdentityEventException(e.getMessage(), e);
         }
-        return organizationUUID;
     }
 
     /**

--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/test/java/org/wso2/carbon/identity/event/handler/notification/PushNotificationHandlerTest.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/test/java/org/wso2/carbon/identity/event/handler/notification/PushNotificationHandlerTest.java
@@ -21,14 +21,17 @@ package org.wso2.carbon.identity.event.handler.notification;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.MockitoAnnotations;
+import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import org.wso2.carbon.context.CarbonContext;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.event.IdentityEventException;
@@ -755,6 +758,159 @@ public class PushNotificationHandlerTest {
                 any(PushNotificationData.class),
                 any(PushSenderData.class),
                 eq("carbon.super"));
+    }
+
+    @Test
+    public void testHandleEventOrganizationTenantWithAccessingOrgId() throws Exception {
+
+        String orgTenantDomain = "org-tenant";
+        String orgId = "org-uuid-123";
+        String primaryOrgTenantDomain = "primary-tenant";
+
+        Event event = createPushNotificationEvent("FCM", orgTenantDomain);
+
+        try (MockedStatic<NotificationHandlerDataHolder> mockedDataHolder = mockStatic(
+                NotificationHandlerDataHolder.class);
+             MockedStatic<NotificationUtil> mockedNotificationUtil = mockStatic(NotificationUtil.class);
+             MockedStatic<PrivilegedCarbonContext> mockedPrivilegedCarbonContext =
+                     mockStatic(PrivilegedCarbonContext.class)) {
+
+            mockedDataHolder.when(NotificationHandlerDataHolder::getInstance)
+                    .thenReturn(notificationHandlerDataHolder);
+            when(notificationHandlerDataHolder.getOrganizationManager()).thenReturn(organizationManager);
+            when(organizationManager.resolveOrganizationId(orgTenantDomain)).thenReturn(orgId);
+
+            mockedNotificationUtil.when(() -> NotificationUtil.resolveHumanReadableOrganizationName(anyString()))
+                    .thenReturn(SAMPLE_ORGANIZATION_NAME);
+            mockedNotificationUtil.when(() -> NotificationUtil.isOrganization(orgTenantDomain))
+                    .thenReturn(true);
+            mockedNotificationUtil.when(() -> NotificationUtil.getPrimaryTenantDomain(orgId))
+                    .thenReturn(primaryOrgTenantDomain);
+
+            PrivilegedCarbonContext mockPrivilegedContext = mock(PrivilegedCarbonContext.class);
+            mockedPrivilegedCarbonContext.when(PrivilegedCarbonContext::getThreadLocalCarbonContext)
+                    .thenReturn(mockPrivilegedContext);
+            when(mockPrivilegedContext.getAccessingOrganizationId()).thenReturn("accessing-org-id");
+
+            when(notificationHandlerDataHolder.getNotificationSenderManagementService())
+                    .thenReturn(notificationSenderManagementService);
+            PushSenderDTO sender = new PushSenderDTO();
+            sender.setName("PushPublisher");
+            sender.setProvider("FCM");
+            sender.setProviderId("fcm-provider-id");
+            List<PushSenderDTO> pushSenders = new ArrayList<>();
+            pushSenders.add(sender);
+            when(notificationSenderManagementService.getPushSenders(true)).thenReturn(pushSenders);
+            when(notificationHandlerDataHolder.getPushProvider("FCM")).thenReturn(pushProvider);
+
+            pushNotificationHandler.handleEvent(event);
+
+            ArgumentCaptor<PushNotificationData> captor = ArgumentCaptor.forClass(PushNotificationData.class);
+            verify(pushProvider).sendNotification(captor.capture(), any(PushSenderData.class),
+                    eq(orgTenantDomain));
+            PushNotificationData data = captor.getValue();
+            Assert.assertEquals(data.getOrganizationId(), orgId);
+            Assert.assertEquals(data.getPrimaryTenantDomain(), primaryOrgTenantDomain);
+            Assert.assertEquals(data.getOrganizationName(), SAMPLE_ORGANIZATION_NAME);
+        }
+    }
+
+    @Test
+    public void testHandleEventOrganizationTenantWithoutAccessingOrgId() throws Exception {
+
+        String orgTenantDomain = "org-tenant";
+        String orgId = "org-uuid-123";
+
+        Event event = createPushNotificationEvent("FCM", orgTenantDomain);
+
+        try (MockedStatic<NotificationHandlerDataHolder> mockedDataHolder = mockStatic(
+                NotificationHandlerDataHolder.class);
+             MockedStatic<NotificationUtil> mockedNotificationUtil = mockStatic(NotificationUtil.class);
+             MockedStatic<PrivilegedCarbonContext> mockedPrivilegedCarbonContext =
+                     mockStatic(PrivilegedCarbonContext.class)) {
+
+            mockedDataHolder.when(NotificationHandlerDataHolder::getInstance)
+                    .thenReturn(notificationHandlerDataHolder);
+            when(notificationHandlerDataHolder.getOrganizationManager()).thenReturn(organizationManager);
+            when(organizationManager.resolveOrganizationId(orgTenantDomain)).thenReturn(orgId);
+
+            mockedNotificationUtil.when(() -> NotificationUtil.resolveHumanReadableOrganizationName(anyString()))
+                    .thenReturn(SAMPLE_ORGANIZATION_NAME);
+            mockedNotificationUtil.when(() -> NotificationUtil.isOrganization(orgTenantDomain))
+                    .thenReturn(true);
+
+            PrivilegedCarbonContext mockPrivilegedContext = mock(PrivilegedCarbonContext.class);
+            mockedPrivilegedCarbonContext.when(PrivilegedCarbonContext::getThreadLocalCarbonContext)
+                    .thenReturn(mockPrivilegedContext);
+            when(mockPrivilegedContext.getAccessingOrganizationId()).thenReturn(null);
+
+            when(notificationHandlerDataHolder.getNotificationSenderManagementService())
+                    .thenReturn(notificationSenderManagementService);
+            PushSenderDTO sender = new PushSenderDTO();
+            sender.setName("PushPublisher");
+            sender.setProvider("FCM");
+            sender.setProviderId("fcm-provider-id");
+            List<PushSenderDTO> pushSenders = new ArrayList<>();
+            pushSenders.add(sender);
+            when(notificationSenderManagementService.getPushSenders(true)).thenReturn(pushSenders);
+            when(notificationHandlerDataHolder.getPushProvider("FCM")).thenReturn(pushProvider);
+
+            pushNotificationHandler.handleEvent(event);
+
+            ArgumentCaptor<PushNotificationData> captor = ArgumentCaptor.forClass(PushNotificationData.class);
+            verify(pushProvider).sendNotification(captor.capture(), any(PushSenderData.class),
+                    eq(orgTenantDomain));
+            PushNotificationData data = captor.getValue();
+            Assert.assertEquals(data.getOrganizationId(), orgId);
+            Assert.assertNull(data.getPrimaryTenantDomain());
+            Assert.assertEquals(data.getOrganizationName(), SAMPLE_ORGANIZATION_NAME);
+        }
+    }
+
+    /**
+     * Test that when the tenant domain is not an organization, the built PushNotificationData has
+     * null organizationId, organizationName, and primaryTenantDomain.
+     */
+    @Test
+    public void testHandleEventNonOrganizationTenant() throws Exception {
+
+        Event event = createPushNotificationEvent("FCM", "carbon.super");
+
+        try (MockedStatic<NotificationHandlerDataHolder> mockedDataHolder = mockStatic(
+                NotificationHandlerDataHolder.class);
+             MockedStatic<NotificationUtil> mockedNotificationUtil = mockStatic(NotificationUtil.class)) {
+
+            mockedDataHolder.when(NotificationHandlerDataHolder::getInstance)
+                    .thenReturn(notificationHandlerDataHolder);
+            when(notificationHandlerDataHolder.getOrganizationManager()).thenReturn(organizationManager);
+            when(organizationManager.resolveOrganizationId(anyString())).thenReturn("orgId");
+
+            mockedNotificationUtil.when(() -> NotificationUtil.resolveHumanReadableOrganizationName(anyString()))
+                    .thenReturn(SAMPLE_ORGANIZATION_NAME);
+            mockedNotificationUtil.when(() -> NotificationUtil.isOrganization("carbon.super"))
+                    .thenReturn(false);
+
+            when(notificationHandlerDataHolder.getNotificationSenderManagementService())
+                    .thenReturn(notificationSenderManagementService);
+            PushSenderDTO sender = new PushSenderDTO();
+            sender.setName("PushPublisher");
+            sender.setProvider("FCM");
+            sender.setProviderId("fcm-provider-id");
+            List<PushSenderDTO> pushSenders = new ArrayList<>();
+            pushSenders.add(sender);
+            when(notificationSenderManagementService.getPushSenders(true)).thenReturn(pushSenders);
+            when(notificationHandlerDataHolder.getPushProvider("FCM")).thenReturn(pushProvider);
+
+            pushNotificationHandler.handleEvent(event);
+
+            ArgumentCaptor<PushNotificationData> captor = ArgumentCaptor.forClass(PushNotificationData.class);
+            verify(pushProvider).sendNotification(captor.capture(), any(PushSenderData.class),
+                    eq("carbon.super"));
+            PushNotificationData data = captor.getValue();
+            Assert.assertNull(data.getOrganizationId());
+            Assert.assertNull(data.getOrganizationName());
+            Assert.assertNull(data.getPrimaryTenantDomain());
+        }
     }
 
     // ==================== Helper Methods ====================

--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/test/java/org/wso2/carbon/identity/event/handler/notification/util/NotificationUtilTest.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/test/java/org/wso2/carbon/identity/event/handler/notification/util/NotificationUtilTest.java
@@ -611,15 +611,4 @@ public class NotificationUtilTest {
             NotificationUtil.getPrimaryTenantDomain(SAMPLE_ORG_UUID);
         }
     }
-
-    @DataProvider(name = "getOrganizationUUIDDataProvider")
-    public Object[][] getOrganizationUUIDDataProvider() {
-
-        return new Object[][] {
-                // {tenantExists, associatedOrgUUID, expectedResult}
-                {true, SAMPLE_ORG_UUID, SAMPLE_ORG_UUID},
-                {false, null, null},
-                {true, null, null}
-        };
-    }
 }

--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/test/java/org/wso2/carbon/identity/event/handler/notification/util/NotificationUtilTest.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/test/java/org/wso2/carbon/identity/event/handler/notification/util/NotificationUtilTest.java
@@ -43,20 +43,17 @@ import org.wso2.carbon.identity.core.ServiceURLBuilder;
 import org.wso2.carbon.identity.core.URLBuilderException;
 import org.wso2.carbon.identity.core.internal.component.IdentityCoreServiceComponent;
 import org.wso2.carbon.identity.core.util.IdentityConfigParser;
-import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.event.IdentityEventConstants;
 import org.wso2.carbon.identity.event.event.Event;
 import org.wso2.carbon.identity.event.handler.notification.NotificationConstants;
 import org.wso2.carbon.identity.event.handler.notification.internal.NotificationHandlerDataHolder;
 import org.wso2.carbon.identity.event.IdentityEventException;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
+import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementServerException;
 import org.wso2.carbon.identity.organization.management.service.util.OrganizationManagementUtil;
 import org.wso2.carbon.identity.organization.management.service.util.Utils;
-import org.wso2.carbon.user.api.Tenant;
-import org.wso2.carbon.user.core.tenant.TenantManager;
-import org.wso2.carbon.user.api.UserStoreException;
-import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.utils.CarbonUtils;
 import org.wso2.carbon.utils.ConfigurationContextService;
 
@@ -568,6 +565,53 @@ public class NotificationUtilTest {
         }
     }
 
+    /**
+     * Test getPrimaryTenantDomain returns the correct tenant domain when both
+     * getPrimaryOrganizationId and resolveTenantDomain succeed.
+     */
+    @Test
+    public void testGetPrimaryTenantDomain() throws Exception {
+
+        try (MockedStatic<NotificationHandlerDataHolder> mockedDataHolder =
+                     mockStatic(NotificationHandlerDataHolder.class)) {
+
+            NotificationHandlerDataHolder mockDataHolder = mock(NotificationHandlerDataHolder.class);
+            OrganizationManager mockOrgManager = mock(OrganizationManager.class);
+
+            mockedDataHolder.when(NotificationHandlerDataHolder::getInstance).thenReturn(mockDataHolder);
+            when(mockDataHolder.getOrganizationManager()).thenReturn(mockOrgManager);
+            when(mockOrgManager.getPrimaryOrganizationId(SAMPLE_ORG_UUID)).thenReturn("primary-org-id");
+            when(mockOrgManager.resolveTenantDomain("primary-org-id")).thenReturn(SAMPLE_TENANT_DOMAIN);
+
+            String result = NotificationUtil.getPrimaryTenantDomain(SAMPLE_ORG_UUID);
+            assertEquals(result, SAMPLE_TENANT_DOMAIN);
+        }
+    }
+
+    /**
+     * Test getPrimaryTenantDomain throws IdentityEventException when
+     * resolveTenantDomain fails with OrganizationManagementException.
+     */
+    @Test(expectedExceptions = IdentityEventException.class)
+    public void testGetPrimaryTenantDomainThrowsWhenResolveTenantDomainFails()
+            throws Exception {
+
+        try (MockedStatic<NotificationHandlerDataHolder> mockedDataHolder =
+                     mockStatic(NotificationHandlerDataHolder.class)) {
+
+            NotificationHandlerDataHolder mockDataHolder = mock(NotificationHandlerDataHolder.class);
+            OrganizationManager mockOrgManager = mock(OrganizationManager.class);
+
+            mockedDataHolder.when(NotificationHandlerDataHolder::getInstance).thenReturn(mockDataHolder);
+            when(mockDataHolder.getOrganizationManager()).thenReturn(mockOrgManager);
+            when(mockOrgManager.getPrimaryOrganizationId(SAMPLE_ORG_UUID)).thenReturn("primary-org-id");
+            when(mockOrgManager.resolveTenantDomain("primary-org-id"))
+                    .thenThrow(new OrganizationManagementServerException("Error resolving tenant domain"));
+
+            NotificationUtil.getPrimaryTenantDomain(SAMPLE_ORG_UUID);
+        }
+    }
+
     @DataProvider(name = "getOrganizationUUIDDataProvider")
     public Object[][] getOrganizationUUIDDataProvider() {
 
@@ -577,61 +621,5 @@ public class NotificationUtilTest {
                 {false, null, null},
                 {true, null, null}
         };
-    }
-
-    @Test(dataProvider = "getOrganizationUUIDDataProvider")
-    public void testGetOrganizationUUID(boolean tenantExists, String associatedOrgUUID, String expectedResult)
-            throws Exception {
-
-        try (MockedStatic<NotificationHandlerDataHolder> mockedDataHolder =
-                     mockStatic(NotificationHandlerDataHolder.class);
-             MockedStatic<IdentityTenantUtil> mockedIdentityTenantUtil =
-                     mockStatic(IdentityTenantUtil.class)) {
-
-            NotificationHandlerDataHolder mockDataHolderInstance = mock(NotificationHandlerDataHolder.class);
-            RealmService mockRealmService = mock(RealmService.class);
-            TenantManager mockTenantManager = mock(TenantManager.class);
-
-            mockedDataHolder.when(NotificationHandlerDataHolder::getInstance).thenReturn(mockDataHolderInstance);
-            when(mockDataHolderInstance.getRealmService()).thenReturn(mockRealmService);
-            mockedIdentityTenantUtil.when(() -> IdentityTenantUtil.getTenantId(SAMPLE_TENANT_DOMAIN))
-                    .thenReturn(SAMPLE_TENANT_ID);
-            when(mockRealmService.getTenantManager()).thenReturn(mockTenantManager);
-
-            if (tenantExists) {
-                Tenant mockTenant = mock(Tenant.class);
-                when(mockTenant.getAssociatedOrganizationUUID()).thenReturn(associatedOrgUUID);
-                when(mockTenantManager.getTenant(SAMPLE_TENANT_ID)).thenReturn(mockTenant);
-            } else {
-                when(mockTenantManager.getTenant(SAMPLE_TENANT_ID)).thenReturn(null);
-            }
-
-            String result = NotificationUtil.getOrganizationUUID(SAMPLE_TENANT_DOMAIN);
-            assertEquals(result, expectedResult);
-        }
-    }
-
-    @Test(expectedExceptions = IdentityEventException.class)
-    public void testGetOrganizationUUIDThrowsException() throws Exception {
-
-        try (MockedStatic<NotificationHandlerDataHolder> mockedDataHolder =
-                     mockStatic(NotificationHandlerDataHolder.class);
-             MockedStatic<IdentityTenantUtil> mockedIdentityTenantUtil =
-                     mockStatic(IdentityTenantUtil.class)) {
-
-            NotificationHandlerDataHolder mockDataHolderInstance = mock(NotificationHandlerDataHolder.class);
-            RealmService mockRealmService = mock(RealmService.class);
-            TenantManager mockTenantManager = mock(TenantManager.class);
-
-            mockedDataHolder.when(NotificationHandlerDataHolder::getInstance).thenReturn(mockDataHolderInstance);
-            when(mockDataHolderInstance.getRealmService()).thenReturn(mockRealmService);
-            mockedIdentityTenantUtil.when(() -> IdentityTenantUtil.getTenantId(SAMPLE_TENANT_DOMAIN))
-                    .thenReturn(SAMPLE_TENANT_ID);
-            when(mockRealmService.getTenantManager()).thenReturn(mockTenantManager);
-            when(mockTenantManager.getTenant(SAMPLE_TENANT_ID))
-                    .thenThrow(new UserStoreException("User store error"));
-
-            NotificationUtil.getOrganizationUUID(SAMPLE_TENANT_DOMAIN);
-        }
     }
 }

--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/test/java/org/wso2/carbon/identity/event/handler/notification/util/NotificationUtilTest.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/test/java/org/wso2/carbon/identity/event/handler/notification/util/NotificationUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2022-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -43,13 +43,20 @@ import org.wso2.carbon.identity.core.ServiceURLBuilder;
 import org.wso2.carbon.identity.core.URLBuilderException;
 import org.wso2.carbon.identity.core.internal.component.IdentityCoreServiceComponent;
 import org.wso2.carbon.identity.core.util.IdentityConfigParser;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.event.IdentityEventConstants;
 import org.wso2.carbon.identity.event.event.Event;
 import org.wso2.carbon.identity.event.handler.notification.NotificationConstants;
 import org.wso2.carbon.identity.event.handler.notification.internal.NotificationHandlerDataHolder;
+import org.wso2.carbon.identity.event.IdentityEventException;
+import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
 import org.wso2.carbon.identity.organization.management.service.util.OrganizationManagementUtil;
 import org.wso2.carbon.identity.organization.management.service.util.Utils;
+import org.wso2.carbon.user.api.Tenant;
+import org.wso2.carbon.user.core.tenant.TenantManager;
+import org.wso2.carbon.user.api.UserStoreException;
+import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.utils.CarbonUtils;
 import org.wso2.carbon.utils.ConfigurationContextService;
 
@@ -129,6 +136,9 @@ public class NotificationUtilTest {
     private static final String SAMPLE_ORGANIZATION_NAME = "OrganizationA";
     private static final String SAMPLE_LOCALE = "fr-FR";
     private static final String SAMPLE_EMAIL_BODY = "SampleEmailBody";
+    private static final String SAMPLE_TENANT_DOMAIN = "sample.com";
+    private static final String SAMPLE_ORG_UUID = "673b507c-6e29-40e1-8e87-0b24e9a97e12";
+    private static final int SAMPLE_TENANT_ID = 5;
 
     private static final String ACCOUNT_RECOVERY_ENDPOINT_URL = "https://example.com/account/recovery";
     private static final String AUTHENTICATION_ENDPOINT_URL = "https://example.com/authentication";
@@ -520,5 +530,108 @@ public class NotificationUtilTest {
         carbonUtils.when(() -> CarbonUtils.getTransportProxyPort(axisConfiguration, null)).thenReturn(-1);
         carbonUtils.when(() -> CarbonUtils.getServerConfiguration()).thenReturn(serverConfiguration);
         carbonUtils.when(CarbonUtils::getManagementTransport).thenReturn(DUMMY_PROTOCOL);
+    }
+
+    @DataProvider(name = "isOrganizationDataProvider")
+    public Object[][] isOrganizationDataProvider() {
+
+        return new Object[][] {
+                {true},
+                {false}
+        };
+    }
+
+    @Test(dataProvider = "isOrganizationDataProvider")
+    public void testIsOrganization(boolean expected) throws IdentityEventException {
+
+        try (MockedStatic<OrganizationManagementUtil> mockedOrgManagementUtil =
+                     mockStatic(OrganizationManagementUtil.class)) {
+
+            mockedOrgManagementUtil.when(() -> OrganizationManagementUtil.isOrganization(SAMPLE_TENANT_DOMAIN))
+                    .thenReturn(expected);
+
+            boolean result = NotificationUtil.isOrganization(SAMPLE_TENANT_DOMAIN);
+            assertEquals(result, expected);
+        }
+    }
+
+    @Test(expectedExceptions = IdentityEventException.class)
+    public void testIsOrganizationThrowsException() throws IdentityEventException {
+
+        try (MockedStatic<OrganizationManagementUtil> mockedOrgManagementUtil =
+                     mockStatic(OrganizationManagementUtil.class)) {
+
+            mockedOrgManagementUtil.when(() -> OrganizationManagementUtil.isOrganization(SAMPLE_TENANT_DOMAIN))
+                    .thenThrow(new OrganizationManagementException("Organization management error"));
+
+            NotificationUtil.isOrganization(SAMPLE_TENANT_DOMAIN);
+        }
+    }
+
+    @DataProvider(name = "getOrganizationUUIDDataProvider")
+    public Object[][] getOrganizationUUIDDataProvider() {
+
+        return new Object[][] {
+                // {tenantExists, associatedOrgUUID, expectedResult}
+                {true, SAMPLE_ORG_UUID, SAMPLE_ORG_UUID},
+                {false, null, null},
+                {true, null, null}
+        };
+    }
+
+    @Test(dataProvider = "getOrganizationUUIDDataProvider")
+    public void testGetOrganizationUUID(boolean tenantExists, String associatedOrgUUID, String expectedResult)
+            throws Exception {
+
+        try (MockedStatic<NotificationHandlerDataHolder> mockedDataHolder =
+                     mockStatic(NotificationHandlerDataHolder.class);
+             MockedStatic<IdentityTenantUtil> mockedIdentityTenantUtil =
+                     mockStatic(IdentityTenantUtil.class)) {
+
+            NotificationHandlerDataHolder mockDataHolderInstance = mock(NotificationHandlerDataHolder.class);
+            RealmService mockRealmService = mock(RealmService.class);
+            TenantManager mockTenantManager = mock(TenantManager.class);
+
+            mockedDataHolder.when(NotificationHandlerDataHolder::getInstance).thenReturn(mockDataHolderInstance);
+            when(mockDataHolderInstance.getRealmService()).thenReturn(mockRealmService);
+            mockedIdentityTenantUtil.when(() -> IdentityTenantUtil.getTenantId(SAMPLE_TENANT_DOMAIN))
+                    .thenReturn(SAMPLE_TENANT_ID);
+            when(mockRealmService.getTenantManager()).thenReturn(mockTenantManager);
+
+            if (tenantExists) {
+                Tenant mockTenant = mock(Tenant.class);
+                when(mockTenant.getAssociatedOrganizationUUID()).thenReturn(associatedOrgUUID);
+                when(mockTenantManager.getTenant(SAMPLE_TENANT_ID)).thenReturn(mockTenant);
+            } else {
+                when(mockTenantManager.getTenant(SAMPLE_TENANT_ID)).thenReturn(null);
+            }
+
+            String result = NotificationUtil.getOrganizationUUID(SAMPLE_TENANT_DOMAIN);
+            assertEquals(result, expectedResult);
+        }
+    }
+
+    @Test(expectedExceptions = IdentityEventException.class)
+    public void testGetOrganizationUUIDThrowsException() throws Exception {
+
+        try (MockedStatic<NotificationHandlerDataHolder> mockedDataHolder =
+                     mockStatic(NotificationHandlerDataHolder.class);
+             MockedStatic<IdentityTenantUtil> mockedIdentityTenantUtil =
+                     mockStatic(IdentityTenantUtil.class)) {
+
+            NotificationHandlerDataHolder mockDataHolderInstance = mock(NotificationHandlerDataHolder.class);
+            RealmService mockRealmService = mock(RealmService.class);
+            TenantManager mockTenantManager = mock(TenantManager.class);
+
+            mockedDataHolder.when(NotificationHandlerDataHolder::getInstance).thenReturn(mockDataHolderInstance);
+            when(mockDataHolderInstance.getRealmService()).thenReturn(mockRealmService);
+            mockedIdentityTenantUtil.when(() -> IdentityTenantUtil.getTenantId(SAMPLE_TENANT_DOMAIN))
+                    .thenReturn(SAMPLE_TENANT_ID);
+            when(mockRealmService.getTenantManager()).thenReturn(mockTenantManager);
+            when(mockTenantManager.getTenant(SAMPLE_TENANT_ID))
+                    .thenThrow(new UserStoreException("User store error"));
+
+            NotificationUtil.getOrganizationUUID(SAMPLE_TENANT_DOMAIN);
+        }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -536,7 +536,7 @@
         <identity.branding.preference.management.version>1.1.29</identity.branding.preference.management.version>
         <identity.branding.preference.management.version.range>[1.0.1, 2.0.0)</identity.branding.preference.management.version.range>
 
-        <identity.notification.push.version>1.1.1</identity.notification.push.version>
+        <identity.notification.push.version>1.1.4</identity.notification.push.version>
         <identity.notification.push.version.range>[1.0.0, 2.0.0)</identity.notification.push.version.range>
 
         <json.wso2.version>3.0.0.wso2v4</json.wso2.version>

--- a/pom.xml
+++ b/pom.xml
@@ -560,7 +560,7 @@
         <commons-collections.wso2.version.range>[3.2.0,4.0.0)</commons-collections.wso2.version.range>
 
         <!--Carbon Kernel Version-->
-        <carbon.kernel.version>4.10.126</carbon.kernel.version>
+        <carbon.kernel.version>4.12.29</carbon.kernel.version>
         <carbon.kernel.feature.version>4.9.10</carbon.kernel.feature.version>
         <carbon.kernel.imp.pkg.version.range>[4.5.0, 5.0.0)</carbon.kernel.imp.pkg.version.range>
 


### PR DESCRIPTION
## Purpose
The `PushNotificationHandler` incorrectly differentiated between tenant users and sub-organization users by comparing `tenantDomain` with `organizationName` when building the PushNotificationData object. This string comparison is unreliable because a tenant domain and organization name can differ for legitimate tenant users as well, causing tenant users to be misidentified as organization users and resulting in incorrect organization ID values being passed downstream.

## GitHub Issue
- https://github.com/wso2/product-is/issues/27438

## Related PRs

1. identity-notification-push: **(_prerequisite_)** https://github.com/wso2-extensions/identity-notification-push/pull/23

**Note:** PRs marked as **_prerequisite_** must be merged before and bump the new version here.

## Goals
- Correctly identify whether a login flow belongs to a sub-organization or a tenant by using `OrganizationManagementUtil.isOrganization()` instead of a string comparison.
- Retrieve the actual organization ID via `OrganizationManager.resolveOrganizationId()` instead of incorrectly using the tenant domain string as the organization ID.
- Resolve the primary tenant domain for tenant-organization paths (`/t/{tenant}/o/{org}`) using `OrganizationManager.getPrimaryOrganizationId()` and `resolveTenantDomain()`, and pass it downstream via `PushNotificationData.primaryTenantDomain`.

## Approach
- Added two new utility methods to `NotificationUtil`:
  - `isOrganization(String tenantDomain)` — wraps `OrganizationManagementUtil.isOrganization()` with proper exception handling.
  - `getPrimaryTenantDomain(String organizationId)` — resolves the primary organization ID and then its tenant domain via `OrganizationManager`.
- Updated `PushNotificationHandler.buildPushNotificationData()`:
  - Uses `NotificationUtil.isOrganization()` instead of the flawed `!tenantDomain.equals(organizationName)` check.
  - Resolves the organization ID via `OrganizationManager.resolveOrganizationId(tenantDomain)`.
  - Checks `PrivilegedCarbonContext.getAccessingOrganizationId()` to determine if this is a tenant-organization path, and if so, resolves and sets `primaryTenantDomain` on the `PushNotificationData` builder.
- Added comprehensive unit tests covering all code paths for both new utility methods and the three organization/tenant branching scenarios in `PushNotificationHandler`.

## User stories
As a sub-organization user, push notifications should correctly resolve my organization ID so that organization-specific notification configurations are applied. As a tenant user, the system should not incorrectly treat me as a sub-organization user.

## Developer Checklist (Mandatory)
- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.

## Release note
Fixed an issue where the push notification handler incorrectly identified tenant users as sub-organization users due to a flawed string comparison, causing incorrect organization ID resolution. Also added primary tenant domain resolution for tenant-organization paths.

## Documentation
N/A — This is an internal bug fix with no user-facing configuration or API changes.

## Training
N/A

## Certification
N/A — No impact on certification exams. This is an internal logic fix.

## Marketing
N/A

## Automation tests
 - Unit tests (`NotificationUtilTest`)
   - `testIsOrganization` — Parameterized test verifying `true` and `false` return values.
   - `testIsOrganizationThrowsException` — Verifies `OrganizationManagementException` is wrapped as `IdentityEventException`.
   - `testGetPrimaryTenantDomain` — Verifies correct tenant domain is returned when `getPrimaryOrganizationId` and `resolveTenantDomain` succeed.
   - `testGetPrimaryTenantDomainThrowsWhenResolveTenantDomainFails` — Verifies `OrganizationManagementServerException` is wrapped as `IdentityEventException`.
 - Unit tests (`PushNotificationHandlerTest`)
   - `testHandleEventOrganizationTenantWithAccessingOrgId` — Verifies organization tenant with accessing org ID sets `organizationId`, `organizationName`, and `primaryTenantDomain`.
   - `testHandleEventOrganizationTenantWithoutAccessingOrgId` — Verifies organization tenant without accessing org ID sets `organizationId` and `organizationName` but `primaryTenantDomain` is null.
   - `testHandleEventNonOrganizationTenant` — Verifies non-organization tenant has null `organizationId`, `organizationName`, and `primaryTenantDomain`.
 - Integration tests
   - N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Migrations (if applicable)
N/A — No migrations required. This is a logic fix with no schema or configuration changes.

## Test environment
N/A

## Learning
Used `OrganizationManagementUtil.isOrganization()` as the authoritative API for checking organization membership, `OrganizationManager.resolveOrganizationId()` for resolving the organization ID from a tenant domain, and `OrganizationManager.getPrimaryOrganizationId()` + `resolveTenantDomain()` for resolving the primary tenant domain of an organization.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved organization and tenant detection for push notifications; primary tenant domain is now tracked when available.

* **Tests**
  * Added unit tests covering organization vs. tenant flows and primary tenant domain resolution.

* **Chores**
  * Bumped notification and core kernel dependency versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->