### PR TITLE
Add synchronous email notification delivery with circuit breaker support

### DIFF
--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/NotificationConstants.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/NotificationConstants.java
@@ -123,7 +123,7 @@ public class NotificationConstants {
         public static class AdapterErrorCodes {
 
             private AdapterErrorCodes() {
-                
+                                
             }
 
             // Email adapter error codes.
@@ -336,6 +336,7 @@ public class NotificationConstants {
             }
 
             public static final String HANDLE_EVENT = "handle-event";
+            public static final String PUBLISH_SYNC_EMAIL_NOTIFICATION = "publish-sync-email-notification";
         }
 
         /**

--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/NotificationConstants.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/NotificationConstants.java
@@ -200,7 +200,10 @@ public class NotificationConstants {
                             + "Please contact your administrator to verify the email service credentials."),
             UNKNOWN_ERROR("ENH-65017",
                     "The notification could not be delivered due to an unexpected error. "
-                            + "Please try again or contact support.");
+                            + "Please try again or contact support."),
+            EMAIL_NOTIFICATION_THROTTLED("ENH-65018",
+                    "The email could not be delivered because the email service is temporarily suspended "
+                            + "due to repeated failures. Please try again later or contact support.");
 
             private final String code;
             private final String message;

--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/NotificationConstants.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/NotificationConstants.java
@@ -136,7 +136,6 @@ public class NotificationConstants {
             // HTTP adapter error codes.
             public static final String HTTP_CLIENT_INIT_FAILED = "HTTP-OA-65000";
             public static final String HTTP_CLIENT_NOT_INITIALIZED = "HTTP-OA-65001";
-            public static final String HTTP_PUBLISH_FAILED_WITH_RESPONSE = "HTTP-OA-65002";
             public static final String HTTP_PUBLISH_UNAUTHORIZED = "HTTP-OA-65003";
             public static final String HTTP_PUBLISH_FORBIDDEN = "HTTP-OA-65004";
             public static final String HTTP_PUBLISH_BAD_REQUEST = "HTTP-OA-65005";

--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/NotificationConstants.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/NotificationConstants.java
@@ -84,6 +84,10 @@ public class NotificationConstants {
         public static final String ARBITRARY_BODY = "body";
         public static final String ARBITRARY_FOOTER = "footer";
 
+        public static final String SYNC_EMAIL_NOTIFICATION = "syncEmailNotification";
+        public static final String EMAIL_SYNC = "email.sync";
+        public static final String HTTP_SYNC = "http.sync";
+
         public static final String CARBON_PRODUCT_URL_TEMPLATE_PLACEHOLDER = "carbon.product-url";
         public static final String ACCOUNT_RECOVERY_ENDPOINT_PLACEHOLDER = "account.recovery.endpoint-url";
         public static final String AUTHENTICATION_ENDPOINT_PLACEHOLDER = "authentication.endpoint-url";
@@ -113,6 +117,110 @@ public class NotificationConstants {
         public static final String NEW_LINE_CHARACTER_STRING = "\\n";
         public static final String NEW_LINE_CHARACTER_HTML = "<br>";
 
+        /**
+         * Error codes from the event output adapters used for email notification delivery.
+         */
+        public static class AdapterErrorCodes {
+
+            private AdapterErrorCodes() {
+                
+            }
+
+            // Email adapter error codes.
+            public static final String EMAIL_SEND_FAILED = "EMAIL-OA-65000";
+            public static final String EMAIL_MISSING_ADDRESS = "EMAIL-OA-65001";
+            public static final String EMAIL_ENCODING_FAILED = "EMAIL-OA-65002";
+            public static final String EMAIL_AUTH_FAILED = "EMAIL-OA-65003";
+            public static final String EMAIL_SEND_REJECTED = "EMAIL-OA-65004";
+
+            // HTTP adapter error codes.
+            public static final String HTTP_CLIENT_INIT_FAILED = "HTTP-OA-65000";
+            public static final String HTTP_CLIENT_NOT_INITIALIZED = "HTTP-OA-65001";
+            public static final String HTTP_PUBLISH_FAILED_WITH_RESPONSE = "HTTP-OA-65002";
+            public static final String HTTP_PUBLISH_UNAUTHORIZED = "HTTP-OA-65003";
+            public static final String HTTP_PUBLISH_FORBIDDEN = "HTTP-OA-65004";
+            public static final String HTTP_PUBLISH_BAD_REQUEST = "HTTP-OA-65005";
+            public static final String HTTP_PUBLISH_TOO_MANY_REQUESTS = "HTTP-OA-65006";
+            public static final String HTTP_PUBLISH_SERVICE_UNAVAILABLE = "HTTP-OA-65007";
+            public static final String HTTP_PUBLISH_SERVER_ERROR = "HTTP-OA-65008";
+            public static final String HTTP_PUBLISH_FAILED_IO = "HTTP-OA-65009";
+            public static final String HTTP_TOKEN_REFRESH_MISSING_CREDS = "HTTP-OA-65010";
+            public static final String HTTP_TOKEN_FETCH_FAILED = "HTTP-OA-65011";
+        }
+
+        public enum ErrorMessages {
+
+            EMAIL_SEND_FAILED("ENH-65001",
+                    "Your email could not be sent due to a mail server issue. "
+                            + "Please try again or contact support if the problem persists."),
+            EMAIL_MISSING_ADDRESS("ENH-65002",
+                    "Your email could not be sent because no recipient address was provided. "
+                            + "Please try again."),
+            EMAIL_ENCODING_FAILED("ENH-65003",
+                    "Your email could not be sent because the recipient address contains unsupported characters. "
+                            + "Please check the email address and try again."),
+            EMAIL_AUTH_FAILED("ENH-65004",
+                    "Your email could not be sent because the mail server could not verify the sender. "
+                            + "Please contact your administrator to check the email server settings."),
+            EMAIL_SEND_REJECTED("ENH-65005",
+                    "Your email could not be sent because the recipient address was not accepted by the mail "
+                            + "server. Please verify the email address and try again."),
+            HTTP_CLIENT_INIT_FAILED("ENH-65006",
+                    "The email service is not ready. Please contact your administrator to check "
+                            + "the email service configuration."),
+            HTTP_CLIENT_NOT_INITIALIZED("ENH-65007",
+                    "The email service is not ready. Please contact your administrator to check "
+                            + "the email service configuration."),
+            HTTP_PUBLISH_UNAUTHORIZED("ENH-65008",
+                    "The email could not be delivered because access was denied. Please contact your "
+                            + "administrator to verify the email service credentials."),
+            HTTP_PUBLISH_FORBIDDEN("ENH-65009",
+                    "The email could not be delivered because the configured account does not have the "
+                            + "required permissions. Please contact your administrator."),
+            HTTP_PUBLISH_BAD_REQUEST("ENH-65010",
+                    "The email could not be delivered because the email service did not accept "
+                            + "the request. Please contact your administrator."),
+            HTTP_PUBLISH_TOO_MANY_REQUESTS("ENH-65011",
+                    "The email could not be delivered because the email service is receiving too "
+                            + "many requests. Please try again in a few moments."),
+            HTTP_PUBLISH_SERVER_ERROR("ENH-65012",
+                    "The email could not be delivered because the email service encountered an "
+                            + "unexpected error. Please try again or contact support."),
+            HTTP_PUBLISH_SERVICE_UNAVAILABLE("ENH-65013",
+                    "The email could not be delivered because the email service is temporarily "
+                            + "unavailable. Please try again in a few moments."),
+            HTTP_PUBLISH_FAILED_IO("ENH-65014",
+                    "The email could not be delivered because a connection to the email service "
+                            + "could not be established. Please try again or contact support."),
+            HTTP_TOKEN_REFRESH_MISSING_CREDS("ENH-65015",
+                    "The email could not be delivered because the service authentication failed. "
+                            + "Please contact your administrator to verify the email service credentials."),
+            HTTP_TOKEN_FETCH_FAILED("ENH-65016",
+                    "The email could not be delivered because the service authentication failed. "
+                            + "Please contact your administrator to verify the email service credentials."),
+            UNKNOWN_ERROR("ENH-65017",
+                    "The notification could not be delivered due to an unexpected error. "
+                            + "Please try again or contact support.");
+
+            private final String code;
+            private final String message;
+
+            ErrorMessages(String code, String message) {
+
+                this.code = code;
+                this.message = message;
+            }
+
+            public String getCode() {
+
+                return code;
+            }
+
+            public String getMessage() {
+
+                return message;
+            }
+        }
     }
 
     public static class SMSNotification {

--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/NotificationConstants.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/NotificationConstants.java
@@ -149,58 +149,58 @@ public class NotificationConstants {
 
         public enum ErrorMessages {
 
-            EMAIL_SEND_FAILED("ENH-65001",
+            EMAIL_SEND_FAILED("EP-65001",
                     "Your email could not be sent due to a mail server issue. "
                             + "Please try again or contact support if the problem persists."),
-            EMAIL_MISSING_ADDRESS("ENH-65002",
+            EMAIL_MISSING_ADDRESS("EP-65002",
                     "Your email could not be sent because no recipient address was provided. "
                             + "Please try again."),
-            EMAIL_ENCODING_FAILED("ENH-65003",
+            EMAIL_ENCODING_FAILED("EP-65003",
                     "Your email could not be sent because the recipient address contains unsupported characters. "
                             + "Please check the email address and try again."),
-            EMAIL_AUTH_FAILED("ENH-65004",
+            EMAIL_AUTH_FAILED("EP-65004",
                     "Your email could not be sent because the mail server could not verify the sender. "
                             + "Please contact your administrator to check the email server settings."),
-            EMAIL_SEND_REJECTED("ENH-65005",
+            EMAIL_SEND_REJECTED("EP-65005",
                     "Your email could not be sent because the recipient address was not accepted by the mail "
                             + "server. Please verify the email address and try again."),
-            HTTP_CLIENT_INIT_FAILED("ENH-65006",
+            HTTP_CLIENT_INIT_FAILED("EP-65006",
                     "The email service is not ready. Please contact your administrator to check "
                             + "the email service configuration."),
-            HTTP_CLIENT_NOT_INITIALIZED("ENH-65007",
+            HTTP_CLIENT_NOT_INITIALIZED("EP-65007",
                     "The email service is not ready. Please contact your administrator to check "
                             + "the email service configuration."),
-            HTTP_PUBLISH_UNAUTHORIZED("ENH-65008",
+            HTTP_PUBLISH_UNAUTHORIZED("EP-65008",
                     "The email could not be delivered because access was denied. Please contact your "
                             + "administrator to verify the email service credentials."),
-            HTTP_PUBLISH_FORBIDDEN("ENH-65009",
+            HTTP_PUBLISH_FORBIDDEN("EP-65009",
                     "The email could not be delivered because the configured account does not have the "
                             + "required permissions. Please contact your administrator."),
-            HTTP_PUBLISH_BAD_REQUEST("ENH-65010",
+            HTTP_PUBLISH_BAD_REQUEST("EP-65010",
                     "The email could not be delivered because the email service did not accept "
                             + "the request. Please contact your administrator."),
-            HTTP_PUBLISH_TOO_MANY_REQUESTS("ENH-65011",
+            HTTP_PUBLISH_TOO_MANY_REQUESTS("EP-65011",
                     "The email could not be delivered because the email service is receiving too "
                             + "many requests. Please try again in a few moments."),
-            HTTP_PUBLISH_SERVER_ERROR("ENH-65012",
+            HTTP_PUBLISH_SERVER_ERROR("EP-65012",
                     "The email could not be delivered because the email service encountered an "
                             + "unexpected error. Please try again or contact support."),
-            HTTP_PUBLISH_SERVICE_UNAVAILABLE("ENH-65013",
+            HTTP_PUBLISH_SERVICE_UNAVAILABLE("EP-65013",
                     "The email could not be delivered because the email service is temporarily "
                             + "unavailable. Please try again in a few moments."),
-            HTTP_PUBLISH_FAILED_IO("ENH-65014",
+            HTTP_PUBLISH_FAILED_IO("EP-65014",
                     "The email could not be delivered because a connection to the email service "
                             + "could not be established. Please try again or contact support."),
-            HTTP_TOKEN_REFRESH_MISSING_CREDS("ENH-65015",
+            HTTP_TOKEN_REFRESH_MISSING_CREDS("EP-65015",
                     "The email could not be delivered because the service authentication failed. "
                             + "Please contact your administrator to verify the email service credentials."),
-            HTTP_TOKEN_FETCH_FAILED("ENH-65016",
+            HTTP_TOKEN_FETCH_FAILED("EP-65016",
                     "The email could not be delivered because the service authentication failed. "
                             + "Please contact your administrator to verify the email service credentials."),
-            UNKNOWN_ERROR("ENH-65017",
+            UNKNOWN_ERROR("EP-65017",
                     "The notification could not be delivered due to an unexpected error. "
                             + "Please try again or contact support."),
-            EMAIL_NOTIFICATION_THROTTLED("ENH-65018",
+            EMAIL_NOTIFICATION_THROTTLED("EP-65018",
                     "The email could not be delivered because the email service is temporarily suspended "
                             + "due to repeated failures. Please try again later or contact support.");
 

--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/NotificationHandler.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/NotificationHandler.java
@@ -178,38 +178,123 @@ public class NotificationHandler extends DefaultNotificationHandler {
         service.publish(buildDatabridgeEvent(notification, placeHolderDataMap));
     }
 
+    /**
+     * Publishes a notification event to the event stream, propagating consumer errors back to the caller.
+     * Unlike {@link #publishToStream}, this method uses the circuit breaker to throttle requests per tenant
+     * and throws an {@link IdentityEventException} if the publish fails or is throttled.
+     *
+     * @param notification       the notification to be published.
+     * @param placeHolderDataMap placeholder data map containing template variables, including the tenant domain.
+     * @throws IdentityEventException if the circuit breaker throttles the request, or if the event stream
+     *                                consumer reports a known or unknown failure.
+     */
     protected void publishToStreamAndNotifyErrors(Notification notification,
             Map<String, String> placeHolderDataMap) throws IdentityEventException {
 
         EventStreamService service = NotificationHandlerDataHolder.getInstance().getEventStreamService();
         String tenantDomain = placeHolderDataMap.get(NotificationConstants.TENANT_DOMAIN);
-        Decision aquireDecision = CircuitBreakerManager.getInstance().tryAcquire(tenantDomain, TenantService.EMAIL_NOTIFICATION);
-        if (aquireDecision.isAllowed()) {
+        Decision acquireDecision = CircuitBreakerManager.getInstance().tryAcquire(tenantDomain, TenantService.EMAIL_NOTIFICATION);
+        if (acquireDecision.isAllowed()) {
+            if (log.isDebugEnabled()) {
+                log.debug("Circuit breaker allowed sync email notification for tenant: " + tenantDomain
+                        + ". Attempting to publish.");
+            }
             boolean publishSucceeded = false;
             try {
                 service.publishAndNotifyErrors(buildDatabridgeEvent(notification, placeHolderDataMap));
                 publishSucceeded = true;
+                if (log.isDebugEnabled()) {
+                    log.debug("Sync email notification published successfully for tenant: " + tenantDomain);
+                }
+                if (LoggerUtils.isDiagnosticLogsEnabled()) {
+                    DiagnosticLog.DiagnosticLogBuilder diagnosticLogBuilder =
+                            new DiagnosticLog.DiagnosticLogBuilder(
+                                    NotificationConstants.LogConstants.NOTIFICATION_HANDLER_SERVICE,
+                                    NotificationConstants.LogConstants.ActionIDs.PUBLISH_SYNC_EMAIL_NOTIFICATION);
+                    diagnosticLogBuilder
+                            .inputParam(NotificationConstants.LogConstants.InputKeys.TENANT_DOMAIN, tenantDomain)
+                            .resultMessage("Sync email notification published successfully.")
+                            .resultStatus(DiagnosticLog.ResultStatus.SUCCESS)
+                            .logDetailLevel(DiagnosticLog.LogDetailLevel.INTERNAL_SYSTEM);
+                    LoggerUtils.triggerDiagnosticLogEvent(diagnosticLogBuilder);
+                }
             } catch (EventStreamException e) {
                 IdentityEventException resolved = null;
                 if (e instanceof AggregatedConsumerFailureException) {
+                    int failureCount = ((AggregatedConsumerFailureException) e).getFailures().size();
+                    if (log.isDebugEnabled()) {
+                        log.debug("Sync email notification encountered " + failureCount
+                                + " aggregated consumer failure(s) for tenant: " + tenantDomain);
+                    }
                     for (ConsumerFailureException failure : ((AggregatedConsumerFailureException) e).getFailures()) {
                         resolved = resolveConsumerFailure(failure);
                         if (resolved != null) break;
                     }
                 } else if (e instanceof ConsumerFailureException) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Sync email notification encountered a consumer failure for tenant: "
+                                + tenantDomain);
+                    }
                     resolved = resolveConsumerFailure((ConsumerFailureException) e);
                 }
                 if (resolved != null) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Resolved sync email consumer failure for tenant: " + tenantDomain
+                                + ". Error: " + resolved.getMessage());
+                    }
+                    if (LoggerUtils.isDiagnosticLogsEnabled()) {
+                        DiagnosticLog.DiagnosticLogBuilder diagnosticLogBuilder =
+                                new DiagnosticLog.DiagnosticLogBuilder(
+                                        NotificationConstants.LogConstants.NOTIFICATION_HANDLER_SERVICE,
+                                        NotificationConstants.LogConstants.ActionIDs.PUBLISH_SYNC_EMAIL_NOTIFICATION);
+                        diagnosticLogBuilder
+                                .inputParam(NotificationConstants.LogConstants.InputKeys.TENANT_DOMAIN, tenantDomain)
+                                .resultMessage("Sync email notification failed: " + resolved.getMessage())
+                                .resultStatus(DiagnosticLog.ResultStatus.FAILED)
+                                .logDetailLevel(DiagnosticLog.LogDetailLevel.INTERNAL_SYSTEM);
+                        LoggerUtils.triggerDiagnosticLogEvent(diagnosticLogBuilder);
+                    }
                     throw resolved;
+                }
+                if (log.isDebugEnabled()) {
+                    log.debug("Unresolvable consumer failure during sync email notification for tenant: "
+                            + tenantDomain, e);
+                }
+                if (LoggerUtils.isDiagnosticLogsEnabled()) {
+                    DiagnosticLog.DiagnosticLogBuilder diagnosticLogBuilder =
+                            new DiagnosticLog.DiagnosticLogBuilder(
+                                    NotificationConstants.LogConstants.NOTIFICATION_HANDLER_SERVICE,
+                                    NotificationConstants.LogConstants.ActionIDs.PUBLISH_SYNC_EMAIL_NOTIFICATION);
+                    diagnosticLogBuilder
+                            .inputParam(NotificationConstants.LogConstants.InputKeys.TENANT_DOMAIN, tenantDomain)
+                            .resultMessage("Sync email notification failed due to an unexpected consumer error.")
+                            .resultStatus(DiagnosticLog.ResultStatus.FAILED)
+                            .logDetailLevel(DiagnosticLog.LogDetailLevel.INTERNAL_SYSTEM);
+                    LoggerUtils.triggerDiagnosticLogEvent(diagnosticLogBuilder);
                 }
                 throw new IdentityEventException(
                     EmailNotification.ErrorMessages.UNKNOWN_ERROR.getCode(),
                     EmailNotification.ErrorMessages.UNKNOWN_ERROR.getMessage(), e);
             } finally {
                 CircuitBreakerManager.getInstance().onComplete(
-                    tenantDomain, TenantService.EMAIL_NOTIFICATION, aquireDecision, publishSucceeded);
+                    tenantDomain, TenantService.EMAIL_NOTIFICATION, acquireDecision, publishSucceeded);
             }
         } else {
+            if (log.isDebugEnabled()) {
+                log.debug("Sync email notification throttled by circuit breaker for tenant: " + tenantDomain);
+            }
+            if (LoggerUtils.isDiagnosticLogsEnabled()) {
+                DiagnosticLog.DiagnosticLogBuilder diagnosticLogBuilder =
+                        new DiagnosticLog.DiagnosticLogBuilder(
+                                NotificationConstants.LogConstants.NOTIFICATION_HANDLER_SERVICE,
+                                NotificationConstants.LogConstants.ActionIDs.PUBLISH_SYNC_EMAIL_NOTIFICATION);
+                diagnosticLogBuilder
+                        .inputParam(NotificationConstants.LogConstants.InputKeys.TENANT_DOMAIN, tenantDomain)
+                        .resultMessage("Sync email notification throttled by circuit breaker.")
+                        .resultStatus(DiagnosticLog.ResultStatus.FAILED)
+                        .logDetailLevel(DiagnosticLog.LogDetailLevel.INTERNAL_SYSTEM);
+                LoggerUtils.triggerDiagnosticLogEvent(diagnosticLogBuilder);
+            }
             throw new IdentityEventException(
                     EmailNotification.ErrorMessages.EMAIL_NOTIFICATION_THROTTLED.getCode(),
                     EmailNotification.ErrorMessages.EMAIL_NOTIFICATION_THROTTLED.getMessage());

--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/NotificationHandler.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/NotificationHandler.java
@@ -185,9 +185,10 @@ public class NotificationHandler extends DefaultNotificationHandler {
         String tenantDomain = placeHolderDataMap.get(NotificationConstants.TENANT_DOMAIN);
         Decision aquireDecision = CircuitBreakerManager.getInstance().tryAcquire(tenantDomain, TenantService.EMAIL_NOTIFICATION);
         if (aquireDecision.isAllowed()) {
-            boolean publishSucceeded = true;
+            boolean publishSucceeded = false;
             try {
                 service.publishAndNotifyErrors(buildDatabridgeEvent(notification, placeHolderDataMap));
+                publishSucceeded = true;
             } catch (EventStreamException e) {
                 IdentityEventException resolved = null;
                 if (e instanceof AggregatedConsumerFailureException) {
@@ -199,9 +200,11 @@ public class NotificationHandler extends DefaultNotificationHandler {
                     resolved = resolveConsumerFailure((ConsumerFailureException) e);
                 }
                 if (resolved != null) {
-                    publishSucceeded = false;
                     throw resolved;
                 }
+                throw new IdentityEventException(
+                    EmailNotification.ErrorMessages.UNKNOWN_ERROR.getCode(),
+                    EmailNotification.ErrorMessages.UNKNOWN_ERROR.getMessage(), e);
             } finally {
                 CircuitBreakerManager.getInstance().onComplete(
                     tenantDomain, TenantService.EMAIL_NOTIFICATION, aquireDecision, publishSucceeded);

--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/NotificationHandler.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/NotificationHandler.java
@@ -185,6 +185,7 @@ public class NotificationHandler extends DefaultNotificationHandler {
         String tenantDomain = placeHolderDataMap.get(NotificationConstants.TENANT_DOMAIN);
         Decision aquireDecision = CircuitBreakerManager.getInstance().tryAcquire(tenantDomain, TenantService.EMAIL_NOTIFICATION);
         if (aquireDecision.isAllowed()) {
+            boolean publishSucceeded = true;
             try {
                 service.publishAndNotifyErrors(buildDatabridgeEvent(notification, placeHolderDataMap));
             } catch (EventStreamException e) {
@@ -198,16 +199,12 @@ public class NotificationHandler extends DefaultNotificationHandler {
                     resolved = resolveConsumerFailure((ConsumerFailureException) e);
                 }
                 if (resolved != null) {
-                    CircuitBreakerManager.getInstance().onComplete(
-                            tenantDomain, TenantService.EMAIL_NOTIFICATION, aquireDecision, false);
-                    aquireDecision = null;
+                    publishSucceeded = false;
                     throw resolved;
                 }
             } finally {
-                if (aquireDecision != null) {
-                    CircuitBreakerManager.getInstance().onComplete(
-                        tenantDomain, TenantService.EMAIL_NOTIFICATION, aquireDecision, true);
-                }
+                CircuitBreakerManager.getInstance().onComplete(
+                    tenantDomain, TenantService.EMAIL_NOTIFICATION, aquireDecision, publishSucceeded);
             }
         } else {
             throw new IdentityEventException(
@@ -235,7 +232,8 @@ public class NotificationHandler extends DefaultNotificationHandler {
 
         if (errorCode == null) {
             return new IdentityEventException(
-                    EmailNotification.ErrorMessages.UNKNOWN_ERROR.getMessage(), cause);
+                EmailNotification.ErrorMessages.UNKNOWN_ERROR.getCode(),
+                EmailNotification.ErrorMessages.UNKNOWN_ERROR.getMessage(), cause);
         }
         switch (errorCode) {
             case EmailNotification.AdapterErrorCodes.EMAIL_SEND_FAILED:

--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/NotificationHandler.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/NotificationHandler.java
@@ -28,6 +28,9 @@ import org.wso2.carbon.event.stream.core.exception.AggregatedConsumerFailureExce
 import org.wso2.carbon.event.stream.core.exception.ConsumerFailureException;
 import org.wso2.carbon.event.stream.core.exception.EventStreamException;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
+import org.wso2.carbon.identity.core.circuitbreaker.CircuitBreakerManager;
+import org.wso2.carbon.identity.core.circuitbreaker.Decision;
+import org.wso2.carbon.identity.core.circuitbreaker.TenantService;
 import org.wso2.carbon.identity.event.IdentityEventConstants;
 import org.wso2.carbon.identity.event.IdentityEventException;
 import org.wso2.carbon.identity.event.event.Event;
@@ -179,22 +182,37 @@ public class NotificationHandler extends DefaultNotificationHandler {
             Map<String, String> placeHolderDataMap) throws IdentityEventException {
 
         EventStreamService service = NotificationHandlerDataHolder.getInstance().getEventStreamService();
-        try {
-            service.publishAndNotifyErrors(buildDatabridgeEvent(notification, placeHolderDataMap));
-        } catch (EventStreamException e) {
-            if (e instanceof AggregatedConsumerFailureException) {
-                for (ConsumerFailureException failure : ((AggregatedConsumerFailureException) e).getFailures()) {
-                    IdentityEventException resolved = resolveConsumerFailure(failure);
-                    if (resolved != null) {
-                        throw resolved;
+        String tenantDomain = placeHolderDataMap.get(NotificationConstants.TENANT_DOMAIN);
+        Decision aquireDecision = CircuitBreakerManager.getInstance().tryAcquire(tenantDomain, TenantService.EMAIL_NOTIFICATION);
+        if (aquireDecision.isAllowed()) {
+            try {
+                service.publishAndNotifyErrors(buildDatabridgeEvent(notification, placeHolderDataMap));
+            } catch (EventStreamException e) {
+                IdentityEventException resolved = null;
+                if (e instanceof AggregatedConsumerFailureException) {
+                    for (ConsumerFailureException failure : ((AggregatedConsumerFailureException) e).getFailures()) {
+                        resolved = resolveConsumerFailure(failure);
+                        if (resolved != null) break;
                     }
+                } else if (e instanceof ConsumerFailureException) {
+                    resolved = resolveConsumerFailure((ConsumerFailureException) e);
                 }
-            } else if (e instanceof ConsumerFailureException) {
-                IdentityEventException resolved = resolveConsumerFailure((ConsumerFailureException) e);
                 if (resolved != null) {
+                    CircuitBreakerManager.getInstance().onComplete(
+                            tenantDomain, TenantService.EMAIL_NOTIFICATION, aquireDecision, false);
+                    aquireDecision = null;
                     throw resolved;
                 }
+            } finally {
+                if (aquireDecision != null) {
+                    CircuitBreakerManager.getInstance().onComplete(
+                        tenantDomain, TenantService.EMAIL_NOTIFICATION, aquireDecision, true);
+                }
             }
+        } else {
+            throw new IdentityEventException(
+                    EmailNotification.ErrorMessages.EMAIL_NOTIFICATION_THROTTLED.getCode(),
+                    EmailNotification.ErrorMessages.EMAIL_NOTIFICATION_THROTTLED.getMessage());
         }
     }
 

--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/NotificationHandler.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/NotificationHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2016-2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -22,11 +22,16 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.email.mgt.util.I18nEmailUtil;
+import org.wso2.carbon.event.output.adapter.core.exception.OutputEventAdapterException;
 import org.wso2.carbon.event.stream.core.EventStreamService;
+import org.wso2.carbon.event.stream.core.exception.AggregatedConsumerFailureException;
+import org.wso2.carbon.event.stream.core.exception.ConsumerFailureException;
+import org.wso2.carbon.event.stream.core.exception.EventStreamException;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.event.IdentityEventConstants;
 import org.wso2.carbon.identity.event.IdentityEventException;
 import org.wso2.carbon.identity.event.event.Event;
+import org.wso2.carbon.identity.event.handler.notification.NotificationConstants.EmailNotification;
 import org.wso2.carbon.identity.event.handler.notification.email.bean.Notification;
 import org.wso2.carbon.identity.event.handler.notification.internal.NotificationHandlerDataHolder;
 import org.wso2.carbon.identity.event.handler.notification.util.NotificationUtil;
@@ -54,7 +59,7 @@ public class NotificationHandler extends DefaultNotificationHandler {
         //property. Then it will get the first priority.
         String notificationTemplate = getNotificationTemplate(event);
         if(StringUtils.isNotEmpty(notificationTemplate)){
-            event.getEventProperties().put(NotificationConstants.EmailNotification.EMAIL_TEMPLATE_TYPE,
+            event.getEventProperties().put(EmailNotification.EMAIL_TEMPLATE_TYPE,
                     notificationTemplate);
         }
         Map<String, String> arbitraryDataMap = new HashMap<>();
@@ -85,7 +90,7 @@ public class NotificationHandler extends DefaultNotificationHandler {
                 OrganizationManager organizationManager =
                         NotificationHandlerDataHolder.getInstance().getOrganizationManager();
                 String organizationId = organizationManager.resolveOrganizationId(tenantDomain);
-                arbitraryDataMap.put(NotificationConstants.EmailNotification.ORGANIZATION_ID_PLACEHOLDER,
+                arbitraryDataMap.put(EmailNotification.ORGANIZATION_ID_PLACEHOLDER,
                         organizationId);
             }
         } catch (OrganizationManagementException e) {
@@ -107,20 +112,33 @@ public class NotificationHandler extends DefaultNotificationHandler {
         String streamDefinitionID = getStreamDefinitionID(event);
         //This stream-id was set to the map to pass to the publishToStream method only to avoid API change.
         arbitraryDataMap.put("tmp-stream-id", streamDefinitionID);
-        publishToStream(notification, arbitraryDataMap);
+        if (isSyncEmailDelivery(arbitraryDataMap)) {
+            publishToStreamAndNotifyErrors(notification, arbitraryDataMap);
+        } else {
+            publishToStream(notification, arbitraryDataMap);
+        }
     }
 
-    protected void publishToStream(Notification notification, Map<String, String> placeHolderDataMap) {
+    private boolean isSyncEmailDelivery(Map<String, String> arbitraryDataMap) {
 
-        EventStreamService service = NotificationHandlerDataHolder.getInstance().getEventStreamService();
+        String syncValue = arbitraryDataMap.remove(EmailNotification.SYNC_EMAIL_NOTIFICATION);
+        if (Boolean.parseBoolean(syncValue)) {
+            arbitraryDataMap.put(EmailNotification.EMAIL_SYNC, Boolean.TRUE.toString());
+            arbitraryDataMap.put(EmailNotification.HTTP_SYNC, Boolean.TRUE.toString());
+            return true;
+        }
+        return false;
+    }
+
+    private org.wso2.carbon.databridge.commons.Event buildDatabridgeEvent(Notification notification,
+            Map<String, String> placeHolderDataMap) {
 
         org.wso2.carbon.databridge.commons.Event databridgeEvent = new org.wso2.carbon.databridge.commons.Event();
         databridgeEvent.setTimeStamp(System.currentTimeMillis());
-        Map<String, String> arbitraryDataMap = new HashMap<>();
-
         databridgeEvent.setStreamId(placeHolderDataMap.remove("tmp-stream-id"));
 
-        arbitraryDataMap.put(NotificationConstants.EmailNotification.ARBITRARY_EVENT_TYPE, I18nEmailUtil.
+        Map<String, String> arbitraryDataMap = new HashMap<>();
+        arbitraryDataMap.put(EmailNotification.ARBITRARY_EVENT_TYPE, I18nEmailUtil.
                 getNormalizedName(notification.getTemplate().getTemplateDisplayName()));
         arbitraryDataMap.put(IdentityEventConstants.EventProperty.USER_NAME,
                 placeHolderDataMap.get(IdentityEventConstants.EventProperty.USER_NAME));
@@ -128,28 +146,151 @@ public class NotificationHandler extends DefaultNotificationHandler {
                 placeHolderDataMap.get(IdentityEventConstants.EventProperty.USER_STORE_DOMAIN));
         arbitraryDataMap.put(IdentityEventConstants.EventProperty.TENANT_DOMAIN,
                 placeHolderDataMap.get(IdentityEventConstants.EventProperty.TENANT_DOMAIN));
-        arbitraryDataMap.put(NotificationConstants.EmailNotification.ARBITRARY_SEND_FROM, notification.getSendFrom());
+        arbitraryDataMap.put(EmailNotification.ARBITRARY_SEND_FROM, notification.getSendFrom());
         for (Map.Entry<String, String> placeHolderDataEntry : placeHolderDataMap.entrySet()) {
             arbitraryDataMap.put(placeHolderDataEntry.getKey(), placeHolderDataEntry.getValue());
         }
-        arbitraryDataMap.put(NotificationConstants.EmailNotification.ARBITRARY_SUBJECT_TEMPLATE, notification.
+        arbitraryDataMap.put(EmailNotification.ARBITRARY_SUBJECT_TEMPLATE, notification.
                 getTemplate().getSubject());
-        arbitraryDataMap.put(NotificationConstants.EmailNotification.ARBITRARY_BODY_TEMPLATE, notification.
+        arbitraryDataMap.put(EmailNotification.ARBITRARY_BODY_TEMPLATE, notification.
                 getTemplate().getBody());
-        arbitraryDataMap.put(NotificationConstants.EmailNotification.ARBITRARY_FOOTER_TEMPLATE, notification.
+        arbitraryDataMap.put(EmailNotification.ARBITRARY_FOOTER_TEMPLATE, notification.
                 getTemplate().getFooter());
-        arbitraryDataMap.put(NotificationConstants.EmailNotification.ARBITRARY_LOCALE, notification.getTemplate().
+        arbitraryDataMap.put(EmailNotification.ARBITRARY_LOCALE, notification.getTemplate().
                 getLocale());
-        arbitraryDataMap.put(NotificationConstants.EmailNotification.ARBITRARY_CONTENT_TYPE, notification.
+        arbitraryDataMap.put(EmailNotification.ARBITRARY_CONTENT_TYPE, notification.
                 getTemplate().getEmailContentType());
-        arbitraryDataMap.put(NotificationConstants.EmailNotification.ARBITRARY_SEND_TO, notification.getSendTo());
-        arbitraryDataMap.put(NotificationConstants.EmailNotification.ARBITRARY_SUBJECT, notification.getSubject());
-        arbitraryDataMap.put(NotificationConstants.EmailNotification.ARBITRARY_BODY, notification.getBody());
-        arbitraryDataMap.put(NotificationConstants.EmailNotification.ARBITRARY_FOOTER, notification.getFooter());
-
+        arbitraryDataMap.put(EmailNotification.ARBITRARY_SEND_TO, notification.getSendTo());
+        arbitraryDataMap.put(EmailNotification.ARBITRARY_SUBJECT, notification.getSubject());
+        arbitraryDataMap.put(EmailNotification.ARBITRARY_BODY, notification.getBody());
+        arbitraryDataMap.put(EmailNotification.ARBITRARY_FOOTER, notification.getFooter());
 
         databridgeEvent.setArbitraryDataMap(arbitraryDataMap);
-        service.publish(databridgeEvent);
+        return databridgeEvent;
+    }
+
+    protected void publishToStream(Notification notification, Map<String, String> placeHolderDataMap) {
+
+        EventStreamService service = NotificationHandlerDataHolder.getInstance().getEventStreamService();
+        service.publish(buildDatabridgeEvent(notification, placeHolderDataMap));
+    }
+
+    protected void publishToStreamAndNotifyErrors(Notification notification,
+            Map<String, String> placeHolderDataMap) throws IdentityEventException {
+
+        EventStreamService service = NotificationHandlerDataHolder.getInstance().getEventStreamService();
+        try {
+            service.publishAndNotifyErrors(buildDatabridgeEvent(notification, placeHolderDataMap));
+        } catch (EventStreamException e) {
+            if (e instanceof AggregatedConsumerFailureException) {
+                for (ConsumerFailureException failure : ((AggregatedConsumerFailureException) e).getFailures()) {
+                    IdentityEventException resolved = resolveConsumerFailure(failure);
+                    if (resolved != null) {
+                        throw resolved;
+                    }
+                }
+            } else if (e instanceof ConsumerFailureException) {
+                IdentityEventException resolved = resolveConsumerFailure((ConsumerFailureException) e);
+                if (resolved != null) {
+                    throw resolved;
+                }
+            }
+        }
+    }
+
+    private IdentityEventException resolveConsumerFailure(ConsumerFailureException failure) {
+
+        Throwable cause = failure.getCause();
+        if (!(cause instanceof EventStreamException)) {
+            return null;
+        }
+        Throwable adapterCause = cause.getCause();
+        if (!(adapterCause instanceof OutputEventAdapterException)) {
+            return null;
+        }
+        OutputEventAdapterException adapterEx = (OutputEventAdapterException) adapterCause;
+        return buildAdapterErrorException(adapterEx.getErrorCode(), failure);
+    }
+
+    private IdentityEventException buildAdapterErrorException(String errorCode,
+            ConsumerFailureException cause) {
+
+        if (errorCode == null) {
+            return new IdentityEventException(
+                    EmailNotification.ErrorMessages.UNKNOWN_ERROR.getMessage(), cause);
+        }
+        switch (errorCode) {
+            case EmailNotification.AdapterErrorCodes.EMAIL_SEND_FAILED:
+                return new IdentityEventException(
+                        EmailNotification.ErrorMessages.EMAIL_SEND_FAILED.getCode(),
+                        EmailNotification.ErrorMessages.EMAIL_SEND_FAILED.getMessage(), cause);
+            case EmailNotification.AdapterErrorCodes.EMAIL_MISSING_ADDRESS:
+                return new IdentityEventException(
+                        EmailNotification.ErrorMessages.EMAIL_MISSING_ADDRESS.getCode(),
+                        EmailNotification.ErrorMessages.EMAIL_MISSING_ADDRESS.getMessage(), cause);
+            case EmailNotification.AdapterErrorCodes.EMAIL_ENCODING_FAILED:
+                return new IdentityEventException(
+                        EmailNotification.ErrorMessages.EMAIL_ENCODING_FAILED.getCode(),
+                        EmailNotification.ErrorMessages.EMAIL_ENCODING_FAILED.getMessage(), cause);
+            case EmailNotification.AdapterErrorCodes.EMAIL_AUTH_FAILED:
+                return new IdentityEventException(
+                        EmailNotification.ErrorMessages.EMAIL_AUTH_FAILED.getCode(),
+                        EmailNotification.ErrorMessages.EMAIL_AUTH_FAILED.getMessage(), cause);
+            case EmailNotification.AdapterErrorCodes.EMAIL_SEND_REJECTED:
+                return new IdentityEventException(
+                        EmailNotification.ErrorMessages.EMAIL_SEND_REJECTED.getCode(),
+                        EmailNotification.ErrorMessages.EMAIL_SEND_REJECTED.getMessage(), cause);
+            case EmailNotification.AdapterErrorCodes.HTTP_CLIENT_INIT_FAILED:
+                return new IdentityEventException(
+                        EmailNotification.ErrorMessages.HTTP_CLIENT_INIT_FAILED.getCode(),
+                        EmailNotification.ErrorMessages.HTTP_CLIENT_INIT_FAILED.getMessage(), cause);
+            case EmailNotification.AdapterErrorCodes.HTTP_CLIENT_NOT_INITIALIZED:
+                return new IdentityEventException(
+                        EmailNotification.ErrorMessages.HTTP_CLIENT_NOT_INITIALIZED.getCode(),
+                        EmailNotification.ErrorMessages.HTTP_CLIENT_NOT_INITIALIZED.getMessage(), cause);
+            case EmailNotification.AdapterErrorCodes.HTTP_PUBLISH_UNAUTHORIZED:
+                return new IdentityEventException(
+                        EmailNotification.ErrorMessages.HTTP_PUBLISH_UNAUTHORIZED.getCode(),
+                        EmailNotification.ErrorMessages.HTTP_PUBLISH_UNAUTHORIZED.getMessage(), cause);
+            case EmailNotification.AdapterErrorCodes.HTTP_PUBLISH_FORBIDDEN:
+                return new IdentityEventException(
+                        EmailNotification.ErrorMessages.HTTP_PUBLISH_FORBIDDEN.getCode(),
+                        EmailNotification.ErrorMessages.HTTP_PUBLISH_FORBIDDEN.getMessage(), cause);
+            case EmailNotification.AdapterErrorCodes.HTTP_PUBLISH_BAD_REQUEST:
+                return new IdentityEventException(
+                        EmailNotification.ErrorMessages.HTTP_PUBLISH_BAD_REQUEST.getCode(),
+                        EmailNotification.ErrorMessages.HTTP_PUBLISH_BAD_REQUEST.getMessage(), cause);
+            case EmailNotification.AdapterErrorCodes.HTTP_PUBLISH_TOO_MANY_REQUESTS:
+                return new IdentityEventException(
+                        EmailNotification.ErrorMessages.HTTP_PUBLISH_TOO_MANY_REQUESTS.getCode(),
+                        EmailNotification.ErrorMessages.HTTP_PUBLISH_TOO_MANY_REQUESTS.getMessage(), cause);
+            case EmailNotification.AdapterErrorCodes.HTTP_PUBLISH_SERVER_ERROR:
+                return new IdentityEventException(
+                        EmailNotification.ErrorMessages.HTTP_PUBLISH_SERVER_ERROR.getCode(),
+                        EmailNotification.ErrorMessages.HTTP_PUBLISH_SERVER_ERROR.getMessage(), cause);
+            case EmailNotification.AdapterErrorCodes.HTTP_PUBLISH_SERVICE_UNAVAILABLE:
+                return new IdentityEventException(
+                        EmailNotification.ErrorMessages.HTTP_PUBLISH_SERVICE_UNAVAILABLE.getCode(),
+                        EmailNotification.ErrorMessages.HTTP_PUBLISH_SERVICE_UNAVAILABLE.getMessage(),
+                        cause);
+            case EmailNotification.AdapterErrorCodes.HTTP_PUBLISH_FAILED_IO:
+                return new IdentityEventException(
+                        EmailNotification.ErrorMessages.HTTP_PUBLISH_FAILED_IO.getCode(),
+                        EmailNotification.ErrorMessages.HTTP_PUBLISH_FAILED_IO.getMessage(), cause);
+            case EmailNotification.AdapterErrorCodes.HTTP_TOKEN_REFRESH_MISSING_CREDS:
+                return new IdentityEventException(
+                        EmailNotification.ErrorMessages.HTTP_TOKEN_REFRESH_MISSING_CREDS.getCode(),
+                        EmailNotification.ErrorMessages.HTTP_TOKEN_REFRESH_MISSING_CREDS.getMessage(),
+                        cause);
+            case EmailNotification.AdapterErrorCodes.HTTP_TOKEN_FETCH_FAILED:
+                return new IdentityEventException(
+                        EmailNotification.ErrorMessages.HTTP_TOKEN_FETCH_FAILED.getCode(),
+                        EmailNotification.ErrorMessages.HTTP_TOKEN_FETCH_FAILED.getMessage(), cause);
+            default:
+                return new IdentityEventException(
+                        EmailNotification.ErrorMessages.UNKNOWN_ERROR.getCode(),
+                        EmailNotification.ErrorMessages.UNKNOWN_ERROR.getMessage(), cause);
+        }
     }
 
 

--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/test/java/org/wso2/carbon/identity/event/handler/notification/NotificationHandlerTest.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/test/java/org/wso2/carbon/identity/event/handler/notification/NotificationHandlerTest.java
@@ -1,0 +1,420 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.event.handler.notification;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.MockitoAnnotations;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.wso2.carbon.email.mgt.model.EmailTemplate;
+import org.wso2.carbon.email.mgt.util.I18nEmailUtil;
+import org.wso2.carbon.event.output.adapter.core.exception.OutputEventAdapterException;
+import org.wso2.carbon.event.stream.core.EventStreamService;
+import org.wso2.carbon.event.stream.core.exception.AggregatedConsumerFailureException;
+import org.wso2.carbon.event.stream.core.exception.ConsumerFailureException;
+import org.wso2.carbon.event.stream.core.exception.EventStreamException;
+import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
+import org.wso2.carbon.identity.event.IdentityEventException;
+import org.wso2.carbon.identity.event.event.Event;
+import org.wso2.carbon.identity.event.handler.notification.NotificationConstants.EmailNotification;
+import org.wso2.carbon.identity.event.handler.notification.email.bean.Notification;
+import org.wso2.carbon.identity.event.handler.notification.internal.NotificationHandlerDataHolder;
+import org.wso2.carbon.identity.event.handler.notification.util.NotificationUtil;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for NotificationHandler.
+ */
+public class NotificationHandlerTest {
+
+    @Mock
+    private NotificationHandlerDataHolder dataHolder;
+
+    @Mock
+    private EventStreamService eventStreamService;
+
+    private MockedStatic<NotificationHandlerDataHolder> mockedDataHolder;
+    private MockedStatic<LoggerUtils> mockedLoggerUtils;
+    private MockedStatic<NotificationUtil> mockedNotificationUtil;
+    private MockedStatic<I18nEmailUtil> mockedI18nEmailUtil;
+
+    private TestNotificationHandler handler;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+
+        MockitoAnnotations.openMocks(this);
+        handler = new TestNotificationHandler();
+
+        mockedDataHolder = mockStatic(NotificationHandlerDataHolder.class);
+        mockedLoggerUtils = mockStatic(LoggerUtils.class);
+        mockedNotificationUtil = mockStatic(NotificationUtil.class);
+        mockedI18nEmailUtil = mockStatic(I18nEmailUtil.class);
+
+        mockedDataHolder.when(NotificationHandlerDataHolder::getInstance).thenReturn(dataHolder);
+        when(dataHolder.getEventStreamService()).thenReturn(eventStreamService);
+        mockedLoggerUtils.when(LoggerUtils::isDiagnosticLogsEnabled).thenReturn(false);
+        mockedI18nEmailUtil.when(() -> I18nEmailUtil.getNormalizedName(anyString())).thenReturn("TestTemplate");
+    }
+
+    @AfterMethod
+    public void tearDown() {
+
+        mockedDataHolder.close();
+        mockedLoggerUtils.close();
+        mockedNotificationUtil.close();
+        mockedI18nEmailUtil.close();
+    }
+
+    @Test
+    public void testHandleEvent_asyncPath_whenSyncFlagAbsent() throws Exception {
+
+        Notification notification = buildMockNotification();
+        Event event = new Event("TEST_EVENT", new HashMap<>());
+        mockedNotificationUtil.when(() -> NotificationUtil.buildNotification(any(Event.class), any()))
+                .thenReturn(notification);
+
+        handler.handleEvent(event);
+
+        verify(eventStreamService).publish(any());
+        verify(eventStreamService, never()).publishAndNotifyErrors(any());
+    }
+
+    @Test
+    public void testHandleEvent_asyncPath_whenSyncFlagFalse() throws Exception {
+
+        Notification notification = buildMockNotification();
+        Event event = new Event("TEST_EVENT", new HashMap<>());
+        event.getEventProperties().put(EmailNotification.SYNC_EMAIL_NOTIFICATION, "false");
+        mockedNotificationUtil.when(() -> NotificationUtil.buildNotification(any(Event.class), any()))
+                .thenReturn(notification);
+
+        handler.handleEvent(event);
+
+        verify(eventStreamService).publish(any());
+        verify(eventStreamService, never()).publishAndNotifyErrors(any());
+    }
+
+    @Test
+    public void testHandleEvent_syncPath_whenSyncFlagTrue() throws Exception {
+
+        Notification notification = buildMockNotification();
+        Event event = new Event("TEST_EVENT", new HashMap<>());
+        event.getEventProperties().put(EmailNotification.SYNC_EMAIL_NOTIFICATION, "true");
+        mockedNotificationUtil.when(() -> NotificationUtil.buildNotification(any(Event.class), any()))
+                .thenReturn(notification);
+
+        handler.handleEvent(event);
+
+        verify(eventStreamService).publishAndNotifyErrors(any());
+        verify(eventStreamService, never()).publish(any());
+    }
+
+    @Test
+    public void testHandleEvent_syncPath_addsSyncFlagsAndRemovesSyncNotificationKey() throws Exception {
+
+        Notification notification = buildMockNotification();
+        Event event = new Event("TEST_EVENT", new HashMap<>());
+        event.getEventProperties().put(EmailNotification.SYNC_EMAIL_NOTIFICATION, "true");
+        mockedNotificationUtil.when(() -> NotificationUtil.buildNotification(any(Event.class), any()))
+                .thenReturn(notification);
+
+        handler.handleEvent(event);
+
+        ArgumentCaptor<org.wso2.carbon.databridge.commons.Event> captor =
+                ArgumentCaptor.forClass(org.wso2.carbon.databridge.commons.Event.class);
+        verify(eventStreamService).publishAndNotifyErrors(captor.capture());
+        Map<String, String> arbitraryData = captor.getValue().getArbitraryDataMap();
+        Assert.assertEquals(arbitraryData.get(EmailNotification.EMAIL_SYNC), Boolean.TRUE.toString());
+        Assert.assertEquals(arbitraryData.get(EmailNotification.HTTP_SYNC), Boolean.TRUE.toString());
+        Assert.assertFalse(arbitraryData.containsKey(EmailNotification.SYNC_EMAIL_NOTIFICATION),
+                "SYNC_EMAIL_NOTIFICATION key should be removed from the published event data");
+    }
+
+    @Test
+    public void testHandleEvent_skipsPublishing_whenNotificationIsNull() throws Exception {
+
+        Event event = new Event("TEST_EVENT", new HashMap<>());
+        mockedNotificationUtil.when(() -> NotificationUtil.buildNotification(any(Event.class), any()))
+                .thenReturn(null);
+
+        handler.handleEvent(event);
+
+        verify(eventStreamService, never()).publish(any());
+        verify(eventStreamService, never()).publishAndNotifyErrors(any());
+    }
+
+    @Test
+    public void testPublishToStreamAndNotifyErrors_noException_success() throws Exception {
+
+        handler.publishToStreamAndNotifyErrors(buildMockNotification(), buildPlaceholderMap());
+
+        verify(eventStreamService).publishAndNotifyErrors(any());
+    }
+
+    @Test
+    public void testPublishToStreamAndNotifyErrors_aggregatedFailure_validCauseChain_throwsMappedException()
+            throws Exception {
+
+        ConsumerFailureException failure = buildConsumerFailure(EmailNotification.AdapterErrorCodes.EMAIL_SEND_FAILED);
+        doThrow(new AggregatedConsumerFailureException(Collections.singletonList(failure)))
+                .when(eventStreamService).publishAndNotifyErrors(any());
+
+        try {
+            handler.publishToStreamAndNotifyErrors(buildMockNotification(), buildPlaceholderMap());
+            Assert.fail("Expected IdentityEventException");
+        } catch (IdentityEventException e) {
+            Assert.assertEquals(e.getErrorCode(), EmailNotification.ErrorMessages.EMAIL_SEND_FAILED.getCode());
+        }
+    }
+
+    @Test
+    public void testPublishToStreamAndNotifyErrors_aggregatedFailure_multipleFailures_throwsFirstMapped()
+            throws Exception {
+
+        ConsumerFailureException first = buildConsumerFailure(EmailNotification.AdapterErrorCodes.EMAIL_AUTH_FAILED);
+        ConsumerFailureException second = buildConsumerFailure(EmailNotification.AdapterErrorCodes.EMAIL_SEND_REJECTED);
+        doThrow(new AggregatedConsumerFailureException(Arrays.asList(first, second)))
+                .when(eventStreamService).publishAndNotifyErrors(any());
+
+        try {
+            handler.publishToStreamAndNotifyErrors(buildMockNotification(), buildPlaceholderMap());
+            Assert.fail("Expected IdentityEventException");
+        } catch (IdentityEventException e) {
+            Assert.assertEquals(e.getErrorCode(), EmailNotification.ErrorMessages.EMAIL_AUTH_FAILED.getCode());
+        }
+    }
+
+    @Test
+    public void testPublishToStreamAndNotifyErrors_aggregatedFailure_nonEventStreamCause_swallowed() throws Exception {
+
+        ConsumerFailureException failure = new ConsumerFailureException("type", "stream",
+                new RuntimeException("not EventStreamException"));
+        doThrow(new AggregatedConsumerFailureException(Collections.singletonList(failure)))
+                .when(eventStreamService).publishAndNotifyErrors(any());
+
+        handler.publishToStreamAndNotifyErrors(buildMockNotification(), buildPlaceholderMap());
+    }
+
+    @Test
+    public void testPublishToStreamAndNotifyErrors_aggregatedFailure_noAdapterExceptionCause_swallowed()
+            throws Exception {
+
+        EventStreamException streamEx = new EventStreamException("stream error with no adapter cause");
+        ConsumerFailureException failure = new ConsumerFailureException("type", "stream", streamEx);
+        doThrow(new AggregatedConsumerFailureException(Collections.singletonList(failure)))
+                .when(eventStreamService).publishAndNotifyErrors(any());
+
+        handler.publishToStreamAndNotifyErrors(buildMockNotification(), buildPlaceholderMap());
+    }
+
+    @Test
+    public void testPublishToStreamAndNotifyErrors_singleConsumerFailure_validCauseChain_throwsMappedException()
+            throws Exception {
+
+        ConsumerFailureException failure = buildConsumerFailure(
+                EmailNotification.AdapterErrorCodes.HTTP_PUBLISH_UNAUTHORIZED);
+        doThrow(failure).when(eventStreamService).publishAndNotifyErrors(any());
+
+        try {
+            handler.publishToStreamAndNotifyErrors(buildMockNotification(), buildPlaceholderMap());
+            Assert.fail("Expected IdentityEventException");
+        } catch (IdentityEventException e) {
+            Assert.assertEquals(e.getErrorCode(),
+                    EmailNotification.ErrorMessages.HTTP_PUBLISH_UNAUTHORIZED.getCode());
+        }
+    }
+
+    @Test
+    public void testPublishToStreamAndNotifyErrors_singleConsumerFailure_nonEventStreamCause_swallowed()
+            throws Exception {
+
+        ConsumerFailureException failure = new ConsumerFailureException("type", "stream",
+                new RuntimeException("not EventStreamException"));
+        doThrow(failure).when(eventStreamService).publishAndNotifyErrors(any());
+
+        handler.publishToStreamAndNotifyErrors(buildMockNotification(), buildPlaceholderMap());
+    }
+
+    @Test
+    public void testPublishToStreamAndNotifyErrors_singleConsumerFailure_noAdapterExceptionCause_swallowed()
+            throws Exception {
+
+        EventStreamException streamEx = new EventStreamException("stream error");
+        ConsumerFailureException failure = new ConsumerFailureException("type", "stream", streamEx);
+        doThrow(failure).when(eventStreamService).publishAndNotifyErrors(any());
+
+        handler.publishToStreamAndNotifyErrors(buildMockNotification(), buildPlaceholderMap());
+    }
+
+    @DataProvider(name = "adapterErrorCodeMappings")
+    public Object[][] provideAdapterErrorCodeMappings() {
+
+        return new Object[][] {
+            { EmailNotification.AdapterErrorCodes.EMAIL_SEND_FAILED,
+                    EmailNotification.ErrorMessages.EMAIL_SEND_FAILED },
+            { EmailNotification.AdapterErrorCodes.EMAIL_MISSING_ADDRESS,
+                    EmailNotification.ErrorMessages.EMAIL_MISSING_ADDRESS },
+            { EmailNotification.AdapterErrorCodes.EMAIL_ENCODING_FAILED,
+                    EmailNotification.ErrorMessages.EMAIL_ENCODING_FAILED },
+            { EmailNotification.AdapterErrorCodes.EMAIL_AUTH_FAILED,
+                    EmailNotification.ErrorMessages.EMAIL_AUTH_FAILED },
+            { EmailNotification.AdapterErrorCodes.EMAIL_SEND_REJECTED,
+                    EmailNotification.ErrorMessages.EMAIL_SEND_REJECTED },
+            { EmailNotification.AdapterErrorCodes.HTTP_CLIENT_INIT_FAILED,
+                    EmailNotification.ErrorMessages.HTTP_CLIENT_INIT_FAILED },
+            { EmailNotification.AdapterErrorCodes.HTTP_CLIENT_NOT_INITIALIZED,
+                    EmailNotification.ErrorMessages.HTTP_CLIENT_NOT_INITIALIZED },
+            { EmailNotification.AdapterErrorCodes.HTTP_PUBLISH_UNAUTHORIZED,
+                    EmailNotification.ErrorMessages.HTTP_PUBLISH_UNAUTHORIZED },
+            { EmailNotification.AdapterErrorCodes.HTTP_PUBLISH_FORBIDDEN,
+                    EmailNotification.ErrorMessages.HTTP_PUBLISH_FORBIDDEN },
+            { EmailNotification.AdapterErrorCodes.HTTP_PUBLISH_BAD_REQUEST,
+                    EmailNotification.ErrorMessages.HTTP_PUBLISH_BAD_REQUEST },
+            { EmailNotification.AdapterErrorCodes.HTTP_PUBLISH_TOO_MANY_REQUESTS,
+                    EmailNotification.ErrorMessages.HTTP_PUBLISH_TOO_MANY_REQUESTS },
+            { EmailNotification.AdapterErrorCodes.HTTP_PUBLISH_SERVER_ERROR,
+                    EmailNotification.ErrorMessages.HTTP_PUBLISH_SERVER_ERROR },
+            { EmailNotification.AdapterErrorCodes.HTTP_PUBLISH_SERVICE_UNAVAILABLE,
+                    EmailNotification.ErrorMessages.HTTP_PUBLISH_SERVICE_UNAVAILABLE },
+            { EmailNotification.AdapterErrorCodes.HTTP_PUBLISH_FAILED_IO,
+                    EmailNotification.ErrorMessages.HTTP_PUBLISH_FAILED_IO },
+            { EmailNotification.AdapterErrorCodes.HTTP_TOKEN_REFRESH_MISSING_CREDS,
+                    EmailNotification.ErrorMessages.HTTP_TOKEN_REFRESH_MISSING_CREDS },
+            { EmailNotification.AdapterErrorCodes.HTTP_TOKEN_FETCH_FAILED,
+                    EmailNotification.ErrorMessages.HTTP_TOKEN_FETCH_FAILED },
+        };
+    }
+
+    @Test(dataProvider = "adapterErrorCodeMappings")
+    public void testAdapterErrorCodeMapsToCorrectIdentityEventException(
+            String adapterErrorCode, EmailNotification.ErrorMessages expectedError) throws Exception {
+
+        doThrow(buildConsumerFailure(adapterErrorCode)).when(eventStreamService).publishAndNotifyErrors(any());
+
+        try {
+            handler.publishToStreamAndNotifyErrors(buildMockNotification(), buildPlaceholderMap());
+            Assert.fail("Expected IdentityEventException for adapter error code: " + adapterErrorCode);
+        } catch (IdentityEventException e) {
+            Assert.assertEquals(e.getErrorCode(), expectedError.getCode(),
+                    "Unexpected error code for adapter error: " + adapterErrorCode);
+            Assert.assertEquals(e.getMessage(), expectedError.getMessage(),
+                    "Unexpected message for adapter error: " + adapterErrorCode);
+        }
+    }
+
+    @Test
+    public void testPublishToStreamAndNotifyErrors_unknownAdapterErrorCode_mapsToUnknownError() throws Exception {
+
+        doThrow(buildConsumerFailure("UNKNOWN-ADAPTER-9999")).when(eventStreamService).publishAndNotifyErrors(any());
+
+        try {
+            handler.publishToStreamAndNotifyErrors(buildMockNotification(), buildPlaceholderMap());
+            Assert.fail("Expected IdentityEventException");
+        } catch (IdentityEventException e) {
+            Assert.assertEquals(e.getErrorCode(), EmailNotification.ErrorMessages.UNKNOWN_ERROR.getCode());
+            Assert.assertEquals(e.getMessage(), EmailNotification.ErrorMessages.UNKNOWN_ERROR.getMessage());
+        }
+    }
+
+    @Test
+    public void testPublishToStreamAndNotifyErrors_nullAdapterErrorCode_mapsToUnknownErrorMessage() throws Exception {
+
+        OutputEventAdapterException adapterEx = new OutputEventAdapterException((String) null, "adapter error");
+        EventStreamException streamEx = new EventStreamException("stream error", adapterEx);
+        ConsumerFailureException failure = new ConsumerFailureException("type", "stream", streamEx);
+        doThrow(failure).when(eventStreamService).publishAndNotifyErrors(any());
+
+        try {
+            handler.publishToStreamAndNotifyErrors(buildMockNotification(), buildPlaceholderMap());
+            Assert.fail("Expected IdentityEventException");
+        } catch (IdentityEventException e) {
+            Assert.assertEquals(e.getMessage(), EmailNotification.ErrorMessages.UNKNOWN_ERROR.getMessage());
+        }
+    }
+
+    private ConsumerFailureException buildConsumerFailure(String adapterErrorCode) {
+
+        OutputEventAdapterException adapterEx = new OutputEventAdapterException(adapterErrorCode, "adapter error");
+        EventStreamException streamEx = new EventStreamException("stream error", adapterEx);
+        return new ConsumerFailureException("email-type", "id_gov_notify_stream:1.0.0", streamEx);
+    }
+
+    private Map<String, String> buildPlaceholderMap() {
+
+        Map<String, String> map = new HashMap<>();
+        map.put("tmp-stream-id", "id_gov_notify_stream:1.0.0");
+        return map;
+    }
+
+    private Notification buildMockNotification() {
+
+        Notification notification = mock(Notification.class);
+        EmailTemplate template = mock(EmailTemplate.class);
+        when(notification.getTemplate()).thenReturn(template);
+        when(template.getTemplateDisplayName()).thenReturn("TestTemplate");
+        when(template.getSubject()).thenReturn("Test Subject");
+        when(template.getBody()).thenReturn("Test Body");
+        when(template.getFooter()).thenReturn("Test Footer");
+        when(template.getLocale()).thenReturn("en_US");
+        when(template.getEmailContentType()).thenReturn("text/html");
+        when(notification.getSendFrom()).thenReturn("from@test.com");
+        when(notification.getSendTo()).thenReturn("to@test.com");
+        when(notification.getSubject()).thenReturn("Test Subject");
+        when(notification.getBody()).thenReturn("Test Body");
+        when(notification.getFooter()).thenReturn("Test Footer");
+        return notification;
+    }
+
+    /**
+     * Overrides subscription-property lookups that require a configured handler runtime.
+     */
+    private static class TestNotificationHandler extends NotificationHandler {
+
+        @Override
+        protected String getNotificationTemplate(Event event) throws IdentityEventException {
+
+            return null;
+        }
+
+        @Override
+        public String getStreamDefinitionID(Event event) throws IdentityEventException {
+
+            return "id_gov_notify_stream:1.0.0";
+        }
+    }
+}

--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/test/java/org/wso2/carbon/identity/event/handler/notification/NotificationHandlerTest.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/test/java/org/wso2/carbon/identity/event/handler/notification/NotificationHandlerTest.java
@@ -232,18 +232,25 @@ public class NotificationHandlerTest {
     }
 
     @Test
-    public void testPublishToStreamAndNotifyErrors_aggregatedFailure_nonEventStreamCause_swallowed() throws Exception {
+    public void testPublishToStreamAndNotifyErrors_aggregatedFailure_nonEventStreamCause_throwsUnknownError()
+            throws Exception {
 
         ConsumerFailureException failure = new ConsumerFailureException("type", "stream",
                 new RuntimeException("not EventStreamException"));
         doThrow(new AggregatedConsumerFailureException(Collections.singletonList(failure)))
                 .when(eventStreamService).publishAndNotifyErrors(any());
 
-        handler.publishToStreamAndNotifyErrors(buildMockNotification(), buildPlaceholderMap());
+        try {
+            handler.publishToStreamAndNotifyErrors(buildMockNotification(), buildPlaceholderMap());
+            Assert.fail("Expected IdentityEventException");
+        } catch (IdentityEventException e) {
+            Assert.assertEquals(e.getErrorCode(), EmailNotification.ErrorMessages.UNKNOWN_ERROR.getCode());
+            Assert.assertEquals(e.getMessage(), EmailNotification.ErrorMessages.UNKNOWN_ERROR.getMessage());
+        }
     }
 
     @Test
-    public void testPublishToStreamAndNotifyErrors_aggregatedFailure_noAdapterExceptionCause_swallowed()
+    public void testPublishToStreamAndNotifyErrors_aggregatedFailure_noAdapterExceptionCause_throwsUnknownError()
             throws Exception {
 
         EventStreamException streamEx = new EventStreamException("stream error with no adapter cause");
@@ -251,7 +258,13 @@ public class NotificationHandlerTest {
         doThrow(new AggregatedConsumerFailureException(Collections.singletonList(failure)))
                 .when(eventStreamService).publishAndNotifyErrors(any());
 
-        handler.publishToStreamAndNotifyErrors(buildMockNotification(), buildPlaceholderMap());
+        try {
+            handler.publishToStreamAndNotifyErrors(buildMockNotification(), buildPlaceholderMap());
+            Assert.fail("Expected IdentityEventException");
+        } catch (IdentityEventException e) {
+            Assert.assertEquals(e.getErrorCode(), EmailNotification.ErrorMessages.UNKNOWN_ERROR.getCode());
+            Assert.assertEquals(e.getMessage(), EmailNotification.ErrorMessages.UNKNOWN_ERROR.getMessage());
+        }
     }
 
     @Test
@@ -272,25 +285,37 @@ public class NotificationHandlerTest {
     }
 
     @Test
-    public void testPublishToStreamAndNotifyErrors_singleConsumerFailure_nonEventStreamCause_swallowed()
+    public void testPublishToStreamAndNotifyErrors_singleConsumerFailure_nonEventStreamCause_throwsUnknownError()
             throws Exception {
 
         ConsumerFailureException failure = new ConsumerFailureException("type", "stream",
                 new RuntimeException("not EventStreamException"));
         doThrow(failure).when(eventStreamService).publishAndNotifyErrors(any());
 
-        handler.publishToStreamAndNotifyErrors(buildMockNotification(), buildPlaceholderMap());
+        try {
+            handler.publishToStreamAndNotifyErrors(buildMockNotification(), buildPlaceholderMap());
+            Assert.fail("Expected IdentityEventException");
+        } catch (IdentityEventException e) {
+            Assert.assertEquals(e.getErrorCode(), EmailNotification.ErrorMessages.UNKNOWN_ERROR.getCode());
+            Assert.assertEquals(e.getMessage(), EmailNotification.ErrorMessages.UNKNOWN_ERROR.getMessage());
+        }
     }
 
     @Test
-    public void testPublishToStreamAndNotifyErrors_singleConsumerFailure_noAdapterExceptionCause_swallowed()
+    public void testPublishToStreamAndNotifyErrors_singleConsumerFailure_noAdapterExceptionCause_throwsUnknownError()
             throws Exception {
 
         EventStreamException streamEx = new EventStreamException("stream error");
         ConsumerFailureException failure = new ConsumerFailureException("type", "stream", streamEx);
         doThrow(failure).when(eventStreamService).publishAndNotifyErrors(any());
 
-        handler.publishToStreamAndNotifyErrors(buildMockNotification(), buildPlaceholderMap());
+        try {
+            handler.publishToStreamAndNotifyErrors(buildMockNotification(), buildPlaceholderMap());
+            Assert.fail("Expected IdentityEventException");
+        } catch (IdentityEventException e) {
+            Assert.assertEquals(e.getErrorCode(), EmailNotification.ErrorMessages.UNKNOWN_ERROR.getCode());
+            Assert.assertEquals(e.getMessage(), EmailNotification.ErrorMessages.UNKNOWN_ERROR.getMessage());
+        }
     }
 
     @DataProvider(name = "adapterErrorCodeMappings")

--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/test/java/org/wso2/carbon/identity/event/handler/notification/NotificationHandlerTest.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/test/java/org/wso2/carbon/identity/event/handler/notification/NotificationHandlerTest.java
@@ -35,12 +35,15 @@ import org.wso2.carbon.event.stream.core.exception.AggregatedConsumerFailureExce
 import org.wso2.carbon.event.stream.core.exception.ConsumerFailureException;
 import org.wso2.carbon.event.stream.core.exception.EventStreamException;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
+import org.wso2.carbon.identity.core.circuitbreaker.CircuitBreakerManager;
+import org.wso2.carbon.identity.core.circuitbreaker.TenantService;
 import org.wso2.carbon.identity.event.IdentityEventException;
 import org.wso2.carbon.identity.event.event.Event;
 import org.wso2.carbon.identity.event.handler.notification.NotificationConstants.EmailNotification;
 import org.wso2.carbon.identity.event.handler.notification.email.bean.Notification;
 import org.wso2.carbon.identity.event.handler.notification.internal.NotificationHandlerDataHolder;
 import org.wso2.carbon.identity.event.handler.notification.util.NotificationUtil;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -67,12 +70,17 @@ public class NotificationHandlerTest {
     @Mock
     private EventStreamService eventStreamService;
 
+    @Mock
+    private OrganizationManager organizationManager;
+
     private MockedStatic<NotificationHandlerDataHolder> mockedDataHolder;
     private MockedStatic<LoggerUtils> mockedLoggerUtils;
     private MockedStatic<NotificationUtil> mockedNotificationUtil;
     private MockedStatic<I18nEmailUtil> mockedI18nEmailUtil;
 
     private TestNotificationHandler handler;
+
+    private final String TENANT_DOMAIN = "test";
 
     @BeforeMethod
     public void setUp() throws Exception {
@@ -87,6 +95,7 @@ public class NotificationHandlerTest {
 
         mockedDataHolder.when(NotificationHandlerDataHolder::getInstance).thenReturn(dataHolder);
         when(dataHolder.getEventStreamService()).thenReturn(eventStreamService);
+        when(dataHolder.getOrganizationManager()).thenReturn(organizationManager);
         mockedLoggerUtils.when(LoggerUtils::isDiagnosticLogsEnabled).thenReturn(false);
         mockedI18nEmailUtil.when(() -> I18nEmailUtil.getNormalizedName(anyString())).thenReturn("TestTemplate");
     }
@@ -98,6 +107,7 @@ public class NotificationHandlerTest {
         mockedLoggerUtils.close();
         mockedNotificationUtil.close();
         mockedI18nEmailUtil.close();
+        CircuitBreakerManager.getInstance().invalidateTenantService(TENANT_DOMAIN, TenantService.EMAIL_NOTIFICATION);
     }
 
     @Test
@@ -135,6 +145,7 @@ public class NotificationHandlerTest {
         Notification notification = buildMockNotification();
         Event event = new Event("TEST_EVENT", new HashMap<>());
         event.getEventProperties().put(EmailNotification.SYNC_EMAIL_NOTIFICATION, "true");
+        event.getEventProperties().put(NotificationConstants.TENANT_DOMAIN, TENANT_DOMAIN);
         mockedNotificationUtil.when(() -> NotificationUtil.buildNotification(any(Event.class), any()))
                 .thenReturn(notification);
 
@@ -150,6 +161,7 @@ public class NotificationHandlerTest {
         Notification notification = buildMockNotification();
         Event event = new Event("TEST_EVENT", new HashMap<>());
         event.getEventProperties().put(EmailNotification.SYNC_EMAIL_NOTIFICATION, "true");
+        event.getEventProperties().put(NotificationConstants.TENANT_DOMAIN, TENANT_DOMAIN);
         mockedNotificationUtil.when(() -> NotificationUtil.buildNotification(any(Event.class), any()))
                 .thenReturn(notification);
 
@@ -352,6 +364,41 @@ public class NotificationHandlerTest {
     }
 
     @Test
+    public void testPublishToStreamAndNotifyErrors_circuitBreakerOpensAfterHighFailureRate() throws Exception {
+
+        ConsumerFailureException failure = buildConsumerFailure(EmailNotification.AdapterErrorCodes.EMAIL_SEND_FAILED);
+        doThrow(failure).when(eventStreamService).publishAndNotifyErrors(any());
+
+        int totalCalls = 16;
+        int emailSendFailedCount = 0;
+        int throttledCount = 0;
+        boolean circuitOpened = false;
+
+        for (int i = 0; i < totalCalls; i++) {
+            try {
+                handler.publishToStreamAndNotifyErrors(buildMockNotification(), buildPlaceholderMap());
+                Assert.fail("Expected IdentityEventException on call " + (i + 1));
+            } catch (IdentityEventException e) {
+                String errorCode = e.getErrorCode();
+                if (EmailNotification.ErrorMessages.EMAIL_NOTIFICATION_THROTTLED.getCode().equals(errorCode)) {
+                    circuitOpened = true;
+                    throttledCount++;
+                } else {
+                    Assert.assertFalse(circuitOpened,
+                            "Expected throttled error after circuit opened but got " + errorCode + " on call " + (i + 1));
+                    Assert.assertEquals(errorCode, EmailNotification.ErrorMessages.EMAIL_SEND_FAILED.getCode(),
+                            "Unexpected error code on call " + (i + 1));
+                    emailSendFailedCount++;
+                }
+            }
+        }
+
+        Assert.assertEquals(emailSendFailedCount, 15);
+        Assert.assertEquals(throttledCount, 1);
+        Assert.assertTrue(circuitOpened);
+    }
+
+    @Test
     public void testPublishToStreamAndNotifyErrors_nullAdapterErrorCode_mapsToUnknownErrorMessage() throws Exception {
 
         OutputEventAdapterException adapterEx = new OutputEventAdapterException((String) null, "adapter error");
@@ -378,6 +425,7 @@ public class NotificationHandlerTest {
 
         Map<String, String> map = new HashMap<>();
         map.put("tmp-stream-id", "id_gov_notify_stream:1.0.0");
+        map.put(NotificationConstants.TENANT_DOMAIN, TENANT_DOMAIN);
         return map;
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -578,7 +578,7 @@
         <org.wso2.carbon.database.utils.version.range>[2.1.0,3.0.0)</org.wso2.carbon.database.utils.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>7.8.626</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.11.126</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[7.1.0, 8.0.0)</carbon.identity.framework.imp.pkg.version.range>
 
         <!-- Organization management Version -->

--- a/pom.xml
+++ b/pom.xml
@@ -590,7 +590,7 @@
         </org.wso2.identity.organization.mgt.imp.pkg.version.range>
 
         <!--Carbon Analytics Common Version-->
-        <carbon.analytics.common.version>5.2.10</carbon.analytics.common.version>
+        <carbon.analytics.common.version>5.5.7</carbon.analytics.common.version>
         <carbon.analytics.common.version.range>[5.2.10,6.0.0)</carbon.analytics.common.version.range>
 
         <!-- GSON version -->


### PR DESCRIPTION
## Summary

The existing notification handler publishes emails asynchronously (fire-and-forget), making it impossible for callers to know whether delivery succeeded or failed. This PR adds a synchronous delivery path that propagates errors back to the caller, together with a circuit breaker to prevent cascading failures when the email service is degraded.

### Changes

- **Synchronous delivery path** — when `syncEmailNotification=true` is set in the event properties, the handler calls `publishAndNotifyErrors` instead of `publish`, blocking until delivery completes and surfacing any adapter-level failures as `IdentityEventException`.
- **Circuit breaker integration** — the sync path is guarded by `CircuitBreakerManager` per tenant. If the circuit is open (repeated prior failures), the call is rejected immediately with a throttle error (`ENH-65018`) rather than hammering a degraded email service.
- **Structured error mapping** — added `AdapterErrorCodes` constants and an `ErrorMessages` enum that translate low-level output adapter error codes (e.g. `EMAIL-OA-65003`, `HTTP-OA-65006`) into human-readable, caller-actionable messages with stable `ENH-65xxx` codes.
- **Refactor** — extracted `buildDatabridgeEvent` helper from `publishToStream` to avoid duplication between the async and sync paths.
- **Tests** — added `NotificationHandlerTest` covering synchronous delivery, circuit breaker throttling, and error-code mapping scenarios.

### How it works

```
Event with syncEmailNotification=true
        │
        ▼
isSyncEmailDelivery() → sets email.sync / http.sync flags
        │
        ▼
CircuitBreakerManager.tryAcquire(tenant, EMAIL_NOTIFICATION)
   ├── allowed  → publishAndNotifyErrors → map adapter errors → throw IdentityEventException
   │                                     → onComplete(success/failure)
   └── rejected → throw ENH-65018 (throttled)
```

### Testing

- Unit tests added in `NotificationHandlerTest` covering all new code paths.
- Existing async path is unchanged and unaffected.

## Related Issue
- https://github.com/wso2/product-is/issues/28017

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a synchronous delivery option for email notifications alongside the existing asynchronous flow.
  * Introduced more detailed adapter failure reporting with explicit, user-friendly error codes and messages, including throttling outcomes.
* **Bug Fixes**
  * Improved sync delivery event payloads by adding sync indicators and correctly removing the sync flag from the published data.
* **Tests**
  * Added unit tests covering async vs sync routing, sync payload behavior, error-code/message mapping (including unknown cases), and circuit-breaker throttling.
* **Maintenance**
  * Updated managed dependency versions for platform alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->