### PR TITLE
Refine error messages and consolidate duplicate error codes for email notifications

### DIFF
--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/NotificationConstants.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/NotificationConstants.java
@@ -160,47 +160,40 @@ public class NotificationConstants {
                             + "Please check the email address and try again."),
             EMAIL_AUTH_FAILED("EP-65004",
                     "Your email could not be sent because the mail server could not verify the sender. "
-                            + "Please contact your administrator to check the email server settings."),
+                            + "Please contact your administrator."),
             EMAIL_SEND_REJECTED("EP-65005",
                     "Your email could not be sent because the recipient address was not accepted by the mail "
                             + "server. Please verify the email address and try again."),
             HTTP_CLIENT_INIT_FAILED("EP-65006",
-                    "The email service is not ready. Please contact your administrator to check "
-                            + "the email service configuration."),
-            HTTP_CLIENT_NOT_INITIALIZED("EP-65007",
-                    "The email service is not ready. Please contact your administrator to check "
-                            + "the email service configuration."),
-            HTTP_PUBLISH_UNAUTHORIZED("EP-65008",
+                    "The email service is not ready. Please contact your administrator."),
+            HTTP_PUBLISH_UNAUTHORIZED("EP-65007",
                     "The email could not be delivered because access was denied. Please contact your "
-                            + "administrator to verify the email service credentials."),
-            HTTP_PUBLISH_FORBIDDEN("EP-65009",
+                            + "administrator."),
+            HTTP_PUBLISH_FORBIDDEN("EP-65008",
                     "The email could not be delivered because the configured account does not have the "
                             + "required permissions. Please contact your administrator."),
-            HTTP_PUBLISH_BAD_REQUEST("EP-65010",
+            HTTP_PUBLISH_BAD_REQUEST("EP-65009",
                     "The email could not be delivered because the email service did not accept "
                             + "the request. Please contact your administrator."),
-            HTTP_PUBLISH_TOO_MANY_REQUESTS("EP-65011",
+            HTTP_PUBLISH_TOO_MANY_REQUESTS("EP-65010",
                     "The email could not be delivered because the email service is receiving too "
                             + "many requests. Please try again in a few moments."),
-            HTTP_PUBLISH_SERVER_ERROR("EP-65012",
+            HTTP_PUBLISH_SERVER_ERROR("EP-65011",
                     "The email could not be delivered because the email service encountered an "
                             + "unexpected error. Please try again or contact support."),
-            HTTP_PUBLISH_SERVICE_UNAVAILABLE("EP-65013",
+            HTTP_PUBLISH_SERVICE_UNAVAILABLE("EP-65012",
                     "The email could not be delivered because the email service is temporarily "
                             + "unavailable. Please try again in a few moments."),
-            HTTP_PUBLISH_FAILED_IO("EP-65014",
+            HTTP_PUBLISH_FAILED_IO("EP-65013",
                     "The email could not be delivered because a connection to the email service "
                             + "could not be established. Please try again or contact support."),
-            HTTP_TOKEN_REFRESH_MISSING_CREDS("EP-65015",
+            HTTP_TOKEN_REFRESH_MISSING_CREDS("EP-65014",
                     "The email could not be delivered because the service authentication failed. "
-                            + "Please contact your administrator to verify the email service credentials."),
-            HTTP_TOKEN_FETCH_FAILED("EP-65016",
-                    "The email could not be delivered because the service authentication failed. "
-                            + "Please contact your administrator to verify the email service credentials."),
-            UNKNOWN_ERROR("EP-65017",
+                            + "Please contact your administrator."),
+            UNKNOWN_ERROR("EP-65015",
                     "The notification could not be delivered due to an unexpected error. "
                             + "Please try again or contact support."),
-            EMAIL_NOTIFICATION_THROTTLED("EP-65018",
+            EMAIL_NOTIFICATION_THROTTLED("EP-65016",
                     "The email could not be delivered because the email service is temporarily suspended "
                             + "due to repeated failures. Please try again later or contact support.");
 

--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/NotificationHandler.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/NotificationHandler.java
@@ -345,13 +345,10 @@ public class NotificationHandler extends DefaultNotificationHandler {
                         EmailNotification.ErrorMessages.EMAIL_SEND_REJECTED.getCode(),
                         EmailNotification.ErrorMessages.EMAIL_SEND_REJECTED.getMessage(), cause);
             case EmailNotification.AdapterErrorCodes.HTTP_CLIENT_INIT_FAILED:
+            case EmailNotification.AdapterErrorCodes.HTTP_CLIENT_NOT_INITIALIZED:
                 return new IdentityEventException(
                         EmailNotification.ErrorMessages.HTTP_CLIENT_INIT_FAILED.getCode(),
                         EmailNotification.ErrorMessages.HTTP_CLIENT_INIT_FAILED.getMessage(), cause);
-            case EmailNotification.AdapterErrorCodes.HTTP_CLIENT_NOT_INITIALIZED:
-                return new IdentityEventException(
-                        EmailNotification.ErrorMessages.HTTP_CLIENT_NOT_INITIALIZED.getCode(),
-                        EmailNotification.ErrorMessages.HTTP_CLIENT_NOT_INITIALIZED.getMessage(), cause);
             case EmailNotification.AdapterErrorCodes.HTTP_PUBLISH_UNAUTHORIZED:
                 return new IdentityEventException(
                         EmailNotification.ErrorMessages.HTTP_PUBLISH_UNAUTHORIZED.getCode(),
@@ -382,14 +379,11 @@ public class NotificationHandler extends DefaultNotificationHandler {
                         EmailNotification.ErrorMessages.HTTP_PUBLISH_FAILED_IO.getCode(),
                         EmailNotification.ErrorMessages.HTTP_PUBLISH_FAILED_IO.getMessage(), cause);
             case EmailNotification.AdapterErrorCodes.HTTP_TOKEN_REFRESH_MISSING_CREDS:
+            case EmailNotification.AdapterErrorCodes.HTTP_TOKEN_FETCH_FAILED:
                 return new IdentityEventException(
                         EmailNotification.ErrorMessages.HTTP_TOKEN_REFRESH_MISSING_CREDS.getCode(),
                         EmailNotification.ErrorMessages.HTTP_TOKEN_REFRESH_MISSING_CREDS.getMessage(),
                         cause);
-            case EmailNotification.AdapterErrorCodes.HTTP_TOKEN_FETCH_FAILED:
-                return new IdentityEventException(
-                        EmailNotification.ErrorMessages.HTTP_TOKEN_FETCH_FAILED.getCode(),
-                        EmailNotification.ErrorMessages.HTTP_TOKEN_FETCH_FAILED.getMessage(), cause);
             default:
                 return new IdentityEventException(
                         EmailNotification.ErrorMessages.UNKNOWN_ERROR.getCode(),

--- a/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/test/java/org/wso2/carbon/identity/event/handler/notification/NotificationHandlerTest.java
+++ b/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/test/java/org/wso2/carbon/identity/event/handler/notification/NotificationHandlerTest.java
@@ -335,7 +335,7 @@ public class NotificationHandlerTest {
             { EmailNotification.AdapterErrorCodes.HTTP_CLIENT_INIT_FAILED,
                     EmailNotification.ErrorMessages.HTTP_CLIENT_INIT_FAILED },
             { EmailNotification.AdapterErrorCodes.HTTP_CLIENT_NOT_INITIALIZED,
-                    EmailNotification.ErrorMessages.HTTP_CLIENT_NOT_INITIALIZED },
+                    EmailNotification.ErrorMessages.HTTP_CLIENT_INIT_FAILED },
             { EmailNotification.AdapterErrorCodes.HTTP_PUBLISH_UNAUTHORIZED,
                     EmailNotification.ErrorMessages.HTTP_PUBLISH_UNAUTHORIZED },
             { EmailNotification.AdapterErrorCodes.HTTP_PUBLISH_FORBIDDEN,
@@ -353,7 +353,7 @@ public class NotificationHandlerTest {
             { EmailNotification.AdapterErrorCodes.HTTP_TOKEN_REFRESH_MISSING_CREDS,
                     EmailNotification.ErrorMessages.HTTP_TOKEN_REFRESH_MISSING_CREDS },
             { EmailNotification.AdapterErrorCodes.HTTP_TOKEN_FETCH_FAILED,
-                    EmailNotification.ErrorMessages.HTTP_TOKEN_FETCH_FAILED },
+                    EmailNotification.ErrorMessages.HTTP_TOKEN_REFRESH_MISSING_CREDS },
         };
     }
 


### PR DESCRIPTION
## Summary

- Simplifies user-facing error messages for email notification failures by removing overly specific remediation details (e.g., references to "email server settings" or "email service credentials") to avoid exposing internal configuration hints. Messages now direct users to contact their administrator without revealing specifics.
- Consolidates two pairs of redundant error codes that shared identical semantics:
  - `HTTP_CLIENT_NOT_INITIALIZED` merged into `HTTP_CLIENT_INIT_FAILED` — both indicate the email service is not ready.
  - `HTTP_TOKEN_FETCH_FAILED` merged into `HTTP_TOKEN_REFRESH_MISSING_CREDS` — both indicate service authentication failure.
- Renumbers subsequent error codes (EP-65007 → EP-65016) to close the gaps left by the removed entries.
- Updates unit test mappings to reflect the consolidated error codes.

## Related Issue
- https://github.com/wso2/product-is/issues/28017