### PR TITLE
Fix sub-org user creation failure when root SMS sender uses client-credential auth

### DIFF
--- a/components/notification-sender-config/org.wso2.carbon.identity.notification.sender.tenant.config/src/main/java/org/wso2/carbon/identity/notification/sender/tenant/config/NotificationSenderManagementServiceImpl.java
+++ b/components/notification-sender-config/org.wso2.carbon.identity.notification.sender.tenant.config/src/main/java/org/wso2/carbon/identity/notification/sender/tenant/config/NotificationSenderManagementServiceImpl.java
@@ -29,6 +29,7 @@ import org.osgi.annotation.bundle.Capability;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.event.publisher.core.config.EventPublisherConfiguration;
 import org.wso2.carbon.event.publisher.core.exception.EventPublisherConfigurationException;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementClientException;
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementServerException;
@@ -41,6 +42,7 @@ import org.wso2.carbon.identity.configuration.mgt.core.model.Resource;
 import org.wso2.carbon.identity.configuration.mgt.core.model.ResourceFile;
 import org.wso2.carbon.identity.configuration.mgt.core.model.ResourceTypeAdd;
 import org.wso2.carbon.identity.configuration.mgt.core.model.Resources;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.notification.push.provider.PushProvider;
 import org.wso2.carbon.identity.notification.sender.tenant.config.NotificationSenderManagementConstants.ErrorMessage;
 import org.wso2.carbon.identity.notification.sender.tenant.config.clustering.EventPublisherClusterInvalidationMessage;
@@ -738,11 +740,44 @@ public class NotificationSenderManagementServiceImpl implements NotificationSend
             TokenManager.getInstance().getNewAccessToken(authentication);
             newAccessToken = authentication.getInternalProperties().get(ACCESS_TOKEN_PROP);
             newSmsSenderDTO.getAuthentication().addInternalProperty(ACCESS_TOKEN_PROP, newAccessToken);
-            updateSMSSender(newSmsSenderDTO);
+            updateSMSSender(newSmsSenderDTO, true);
         }
         authentication.addInternalProperty(ACCESS_TOKEN_PROP, newAccessToken);
         authentication.buildAuthenticationHeader();
         return authentication.getAuthHeader();
+    }
+
+    /**
+     * Persist the SMS sender to the owning tenant (primary org for an inherited sender, else the current tenant).
+     *
+     * @param smsSender             SMS sender to persist.
+     * @param inheritTenantSettings Whether to persist an inherited sender to its owning primary organization.
+     * @throws NotificationSenderManagementException If the update fails.
+     */
+    private void updateSMSSender(SMSSenderDTO smsSender, boolean inheritTenantSettings)
+            throws NotificationSenderManagementException {
+
+        String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
+        try {
+            // Sub-org inheriting the sender from the primary organization- persist to that owning (root) tenant.
+            if (inheritTenantSettings && OrganizationManagementUtil.isOrganization(tenantDomain)
+                    && getPublisherResource(smsSender.getName()).isEmpty()) {
+                int primaryTenantId = NotificationSenderUtils.getPrimaryTenantId(tenantDomain);
+                String primaryTenantDomain = IdentityTenantUtil.getTenantDomain(primaryTenantId);
+                try {
+                    FrameworkUtils.startTenantFlow(primaryTenantDomain);
+                    updateSMSSender(smsSender);
+                    return;
+                } finally {
+                    FrameworkUtils.endTenantFlow();
+                }
+            }
+        } catch (OrganizationManagementException e) {
+            throw new NotificationSenderManagementServerException(ERROR_CODE_SERVER_ERRORS_GETTING_EVENT_PUBLISHER,
+                    e.getMessage(), e);
+        }
+        // Persist to the current tenant.
+        updateSMSSender(smsSender);
     }
 
     @Override

--- a/components/notification-sender-config/org.wso2.carbon.identity.notification.sender.tenant.config/src/main/java/org/wso2/carbon/identity/notification/sender/tenant/config/dto/Authentication.java
+++ b/components/notification-sender-config/org.wso2.carbon.identity.notification.sender.tenant.config/src/main/java/org/wso2/carbon/identity/notification/sender/tenant/config/dto/Authentication.java
@@ -102,35 +102,44 @@ public class Authentication {
             LOG.debug("Building authentication header for auth type: " + type);
         }
 
+        Header header;
         switch (type) {
             case BASIC:
                 String credentials = authProperties.get(Property.USERNAME.getName()) + ":" +
                         authProperties.get(Property.PASSWORD.getName());
                 byte[] encodedBytes = Base64.getEncoder().encode(credentials.getBytes(StandardCharsets.UTF_8));
-                return new org.apache.http.message.BasicHeader(
+                header = new org.apache.http.message.BasicHeader(
                         AUTH_HEADER,
                         "Basic " + new String(encodedBytes, StandardCharsets.UTF_8));
+                break;
             case CLIENT_CREDENTIAL:
                 if (internalAuthProperties.get(ACCESS_TOKEN_PROP) == null) {
-                    return null;
+                    header = null;
+                    break;
                 }
-                return new BasicHeader(
+                header = new BasicHeader(
                         AUTH_HEADER,
                         "Bearer " + internalAuthProperties.get(ACCESS_TOKEN_PROP)
                 );
+                break;
             case BEARER:
-                return new BasicHeader(
+                header = new BasicHeader(
                         AUTH_HEADER,
                         "Bearer " + authProperties.get(ACCESS_TOKEN.getName())
                 );
+                break;
             case API_KEY:
-                return new BasicHeader(
+                header = new BasicHeader(
                         authProperties.get(Property.HEADER.getName()),
                         authProperties.get(Property.VALUE.getName())
                 );
+                break;
             default:
-                return null;
+                header = null;
         }
+        // Refresh the cache so a subsequent getAuthHeader() returns the freshly built header.
+        this.authHeader = header;
+        return header;
     }
 
     /**


### PR DESCRIPTION
 ### Purpose
  
- Fixes a failure when creating a user in a **sub-organization** while the **root org** has an SMS notification sender configured with **client-credential** authentication. 
  
### Related Issue

  - https://github.com/wso2/product-is/issues/28084

### Root cause

In `NotificationSenderManagementServiceImpl.rebuildAuthHeaderWithNewToken`: 

1. Returns early for non client-credential auth — this is why none/basic work.
2. Reads the sender via `getSMSSender(name)`, which is org-aware and falls back to the primary/root tenant.
3. Mints a fresh token, then calls `updateSMSSender(...)` to persist it.                                                                                                                                       
4. `updateSMSSender` looks the resource up with the **current-tenant-only** `getPublisherResource(name)` and throws `ERROR_CODE_NO_RESOURCE_EXISTS` when it is absent. 
5. In a sub-org the resource exists only in the root org, so the persist throws.

### Changes                                                                                                                                                                                                     
                                                                                                                                                                                                                 
  #### 1. Org-aware token persistence (`NotificationSenderManagementServiceImpl`)                                                                                                                                 
                                                                                                                                                                                                                 
  The refresh path now persists the refreshed token to the tenant that **owns** the sender resource,                                                                                                             
  via a new private overload `updateSMSSender(SMSSenderDTO, boolean inheritTenantSettings)` (mirrors                                                                                                             
  `getSMSSender(name, boolean)`):                                                                                                                                                                                
                                                                                                                                                                                                                 

 -    **Owned by the current tenant** (root/normal tenant, or a sub-org with its own sender) → persist as before.                                                                                                                                                                                                      
 -    **Inherited by a sub-org** (`inheritTenantSettings && isOrganization && resource absent locally`) → resolve the primary (root) tenant and run `updateSMSSender` inside a `FrameworkUtils` tenant flow switched to that tenant, so the refreshed token is written to the **root** resource.                                                                                                                         
 -    **Non-org / genuinely missing** → still surfaces `ERROR_CODE_NO_RESOURCE_EXISTS`.                                                                                                                            

                                                                                                                                                                                                                 
  A tenant flow is required because `ConfigurationManager` exposes a tenant-scoped read                                                                                                                          
  (`getResourceByTenantId`) but no tenant-scoped write — all writes target the current carbon-context                                                                                                            
  tenant. SMS stores the token as a plain resource attribute (`auth.internal.accessToken`), so the                                                                                                               
  write is a straightforward `replaceResource` in the primary tenant.

  Persisting to root (rather than discarding) keeps the token cache coherent and shared across                                                                                                                   
  sub-orgs: a later send reads the refreshed token via `getSMSSender`'s existing primary-tenant                                                                                                                  
  fallback, avoiding a fresh token mint on every OTP send.                                                                                                                                                       
                                                                                                                                                                                                                 
  #### 2. Auth header cache refresh (`Authentication`)                                                                                                                                                            
                                                                                                                                                                                                                 
  `buildAuthenticationHeader()` now updates the cached `authHeader` field before returning it.                                                                                                                   
  Previously it built a fresh header but left the cache untouched, so `getAuthHeader()` (used by the SMS                                                                                                         
  provider to attach the `Bearer` header on each send) could return a **stale, cached** token after a                                                                                                            
  refresh. Now the cache is refreshed on every build, so a subsequent `getAuthHeader()` returns the                                                                                                              
  freshly built header. Returned values for all auth types are unchanged — only the cache-update side effect is added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SMS sender authentication so refreshed access tokens are applied consistently during authentication header creation.
  * Ensured SMS sender configuration updates are persisted correctly, including when the sender settings belong to a primary (owning) tenant.
  * Fixed cases where inherited sender settings were not stored properly when owned by a primary tenant.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->