### PR TITLE
Add OAuth2 password credential authentication support for HTTP notification providers

### DIFF
--- a/components/notification-sender-config/org.wso2.carbon.identity.notification.sender.tenant.config/src/main/java/org/wso2/carbon/identity/notification/sender/tenant/config/NotificationSenderManagementConstants.java
+++ b/components/notification-sender-config/org.wso2.carbon.identity.notification.sender.tenant.config/src/main/java/org/wso2/carbon/identity/notification/sender/tenant/config/NotificationSenderManagementConstants.java
@@ -97,6 +97,7 @@ public class NotificationSenderManagementConstants {
     public static final String CLIENT_CREDENTIAL = "CLIENT_CREDENTIAL";
     public static final String BEARER = "BEARER";
     public static final String API_KEY = "API_KEY";
+    public static final String PASSWORD_CREDENTIAL = "PASSWORD_CREDENTIAL";
     public static final String NONE = "NONE";
 
     // SMS Sender's main properties.

--- a/components/notification-sender-config/org.wso2.carbon.identity.notification.sender.tenant.config/src/main/java/org/wso2/carbon/identity/notification/sender/tenant/config/NotificationSenderManagementServiceImpl.java
+++ b/components/notification-sender-config/org.wso2.carbon.identity.notification.sender.tenant.config/src/main/java/org/wso2/carbon/identity/notification/sender/tenant/config/NotificationSenderManagementServiceImpl.java
@@ -137,6 +137,7 @@ import static org.wso2.carbon.identity.notification.sender.tenant.config.Notific
 import static org.wso2.carbon.identity.notification.sender.tenant.config.NotificationSenderManagementConstants.NOTIFICATION_SENDER_CONFIGS_RESOURCE_TYPE;
 import static org.wso2.carbon.identity.notification.sender.tenant.config.NotificationSenderManagementConstants.NOTIFICATION_SENDER_CONFIGS_RESOURCE_TYPE_DESCRIPTION;
 import static org.wso2.carbon.identity.notification.sender.tenant.config.NotificationSenderManagementConstants.PASSWORD;
+import static org.wso2.carbon.identity.notification.sender.tenant.config.NotificationSenderManagementConstants.PASSWORD_CREDENTIAL;
 import static org.wso2.carbon.identity.notification.sender.tenant.config.NotificationSenderManagementConstants.POST;
 import static org.wso2.carbon.identity.notification.sender.tenant.config.NotificationSenderManagementConstants.PROVIDER;
 import static org.wso2.carbon.identity.notification.sender.tenant.config.NotificationSenderManagementConstants.PROVIDER_URL;
@@ -310,6 +311,19 @@ public class NotificationSenderManagementServiceImpl implements NotificationSend
         if (CLIENT_CREDENTIAL.equalsIgnoreCase(emailSender.getAuthType())) {
             if (StringUtils.isBlank(emailSender.getProperties().get(CLIENT_ID)) ||
                     StringUtils.isBlank(emailSender.getProperties().get(CLIENT_SECRET)) ||
+                    StringUtils.isBlank(emailSender.getProperties().get(TOKEN_ENDPOINT))) {
+                throw new NotificationSenderManagementClientException(ErrorMessage.ERROR_CODE_INVALID_INPUTS);
+            }
+            return;
+        }
+
+        // If authType is set to PASSWORD, client_id, client_secret, username, password & token_endpoint
+        // should be set in the properties. i.e. ensuring Email Provider is updated via notification sender v2 API.
+        if (PASSWORD_CREDENTIAL.equalsIgnoreCase(emailSender.getAuthType())) {
+            if (StringUtils.isBlank(emailSender.getProperties().get(CLIENT_ID)) ||
+                    StringUtils.isBlank(emailSender.getProperties().get(CLIENT_SECRET)) ||
+                    StringUtils.isBlank(emailSender.getProperties().get(USERNAME)) ||
+                    StringUtils.isBlank(emailSender.getProperties().get(PASSWORD)) ||
                     StringUtils.isBlank(emailSender.getProperties().get(TOKEN_ENDPOINT))) {
                 throw new NotificationSenderManagementClientException(ErrorMessage.ERROR_CODE_INVALID_INPUTS);
             }
@@ -665,11 +679,14 @@ public class NotificationSenderManagementServiceImpl implements NotificationSend
                         + e.getMessage(), e);
             }
         }
-        if (StringUtils.equalsIgnoreCase(CLIENT_CREDENTIAL, emailSender.getAuthType())) {
-            // If the new auth type is client credential, delete the internal access token secret to generate a new one
-            // with the updated credential properties.
+        if (StringUtils.equalsIgnoreCase(CLIENT_CREDENTIAL, emailSender.getAuthType()) ||
+                StringUtils.equalsIgnoreCase(PASSWORD_CREDENTIAL, emailSender.getAuthType())) {
+            // If the new auth type is client credential or password grant, delete the internal access token
+            // secret to generate a new one with the updated credential properties.
+            String tokenBasedAuthType = StringUtils.equalsIgnoreCase(CLIENT_CREDENTIAL, emailSender.getAuthType())
+                    ? CLIENT_CREDENTIAL : PASSWORD_CREDENTIAL;
             try {
-                deleteInternalAccessTokenSecret(EMAIL_PROVIDER);
+                deleteInternalAccessTokenSecret(EMAIL_PROVIDER, tokenBasedAuthType);
             } catch (SecretManagementException e) {
                 log.warn("Error occurred while deleting internal access token secret of email sender: " +
                         emailSender.getName() + ". Error: " + e.getMessage(), e);
@@ -729,7 +746,8 @@ public class NotificationSenderManagementServiceImpl implements NotificationSend
     public Header rebuildAuthHeaderWithNewToken(SMSSenderDTO smsSender) throws NotificationSenderManagementException {
 
         Authentication authentication = smsSender.getAuthentication();
-        if (authentication.getType() != Authentication.Type.CLIENT_CREDENTIAL) {
+        if (authentication.getType() != Authentication.Type.CLIENT_CREDENTIAL
+                && authentication.getType() != Authentication.Type.PASSWORD_CREDENTIAL) {
             return authentication.buildAuthenticationHeader();
         }
 
@@ -1110,22 +1128,25 @@ public class NotificationSenderManagementServiceImpl implements NotificationSend
                     continue;
                 }
                 String key = entry.getKey();
+                boolean isPasswordGrant = PASSWORD_CREDENTIAL.equalsIgnoreCase(emailSender.getAuthType());
                 switch (key) {
                     case USERNAME:
-                        resourceAttributes.add(new Attribute(key, encryptCredential(EMAIL_PROVIDER, BASIC, USERNAME,
-                                entry.getValue())));
+                        resourceAttributes.add(new Attribute(key, encryptCredential(EMAIL_PROVIDER,
+                                isPasswordGrant ? PASSWORD_CREDENTIAL : BASIC, USERNAME, entry.getValue())));
                         break;
                     case PASSWORD:
-                        resourceAttributes.add(new Attribute(key, encryptCredential(EMAIL_PROVIDER, BASIC, PASSWORD,
-                                entry.getValue())));
+                        resourceAttributes.add(new Attribute(key, encryptCredential(EMAIL_PROVIDER,
+                                isPasswordGrant ? PASSWORD_CREDENTIAL : BASIC, PASSWORD, entry.getValue())));
                         break;
                     case CLIENT_SECRET:
-                        resourceAttributes.add(new Attribute(key, encryptCredential(EMAIL_PROVIDER, CLIENT_CREDENTIAL,
-                                CLIENT_SECRET, entry.getValue())));
+                        resourceAttributes.add(new Attribute(key, encryptCredential(EMAIL_PROVIDER,
+                                isPasswordGrant ? PASSWORD_CREDENTIAL : CLIENT_CREDENTIAL, CLIENT_SECRET,
+                                entry.getValue())));
                         break;
                     case CLIENT_ID:
-                        resourceAttributes.add(new Attribute(key, encryptCredential(EMAIL_PROVIDER, CLIENT_CREDENTIAL,
-                                CLIENT_ID, entry.getValue())));
+                        resourceAttributes.add(new Attribute(key, encryptCredential(EMAIL_PROVIDER,
+                                isPasswordGrant ? PASSWORD_CREDENTIAL : CLIENT_CREDENTIAL, CLIENT_ID,
+                                entry.getValue())));
                         break;
                     case ACCESS_TOKEN_PROP:
                         resourceAttributes.add(new Attribute(key, encryptCredential(EMAIL_PROVIDER, BEARER,
@@ -1200,6 +1221,9 @@ public class NotificationSenderManagementServiceImpl implements NotificationSend
                 resource.getAttributes().stream()
                         .filter(attribute -> !(INTERNAL_PROPERTIES.contains(attribute.getKey())))
                         .collect(Collectors.toMap(Attribute::getKey, Attribute::getValue));
+        // Read ahead since iteration order over attributesMap is not guaranteed, and USERNAME/PASSWORD/CLIENT_ID
+        // decryption below needs to know the auth type to look up the secret under the matching tag.
+        boolean isPasswordGrant = PASSWORD_CREDENTIAL.equalsIgnoreCase(attributesMap.get(AUTH_TYPE));
         for (Map.Entry<String, String> entry : attributesMap.entrySet()) {
             if (entry == null || StringUtils.isBlank(entry.getKey()) || StringUtils.equals(entry.getKey(), "null") ||
                     StringUtils.isBlank(entry.getValue()) || StringUtils.equals(entry.getValue(), "null")) {
@@ -1227,7 +1251,8 @@ public class NotificationSenderManagementServiceImpl implements NotificationSend
                 // response.
                 case USERNAME:
                     try {
-                        value = decryptCredential(EMAIL_PROVIDER, BASIC, USERNAME);
+                        value = decryptCredential(EMAIL_PROVIDER,
+                                isPasswordGrant ? PASSWORD_CREDENTIAL : BASIC, USERNAME);
                     } catch (SecretManagementException e) {
                         // Do nothing. As there are existing credentials in plain text.
                     }
@@ -1235,7 +1260,8 @@ public class NotificationSenderManagementServiceImpl implements NotificationSend
                     break;
                 case PASSWORD:
                     try {
-                        value = decryptCredential(EMAIL_PROVIDER, BASIC, PASSWORD);
+                        value = decryptCredential(EMAIL_PROVIDER,
+                                isPasswordGrant ? PASSWORD_CREDENTIAL : BASIC, PASSWORD);
                     } catch (SecretManagementException e) {
                         // Do nothing. As there are existing credentials in plain text.
                     }
@@ -1243,7 +1269,8 @@ public class NotificationSenderManagementServiceImpl implements NotificationSend
                     break;
                 case CLIENT_ID:
                     try {
-                        value = decryptCredential(EMAIL_PROVIDER, CLIENT_CREDENTIAL, CLIENT_ID);
+                        value = decryptCredential(EMAIL_PROVIDER,
+                                isPasswordGrant ? PASSWORD_CREDENTIAL : CLIENT_CREDENTIAL, CLIENT_ID);
                     } catch (SecretManagementException e) {
                         throw new NotificationSenderManagementServerException(
                                 ERROR_CODE_ERROR_WHILE_DECRYPTING_CREDENTIALS, e.getMessage(), e);

--- a/components/notification-sender-config/org.wso2.carbon.identity.notification.sender.tenant.config/src/main/java/org/wso2/carbon/identity/notification/sender/tenant/config/dto/Authentication.java
+++ b/components/notification-sender-config/org.wso2.carbon.identity.notification.sender.tenant.config/src/main/java/org/wso2/carbon/identity/notification/sender/tenant/config/dto/Authentication.java
@@ -113,6 +113,7 @@ public class Authentication {
                         "Basic " + new String(encodedBytes, StandardCharsets.UTF_8));
                 break;
             case CLIENT_CREDENTIAL:
+            case PASSWORD_CREDENTIAL:
                 if (internalAuthProperties.get(ACCESS_TOKEN_PROP) == null) {
                     header = null;
                     break;
@@ -187,6 +188,19 @@ public class Authentication {
                     resolvedAuthProperties.put(Property.HEADER.getName(), getProperty(Property.HEADER));
                     resolvedAuthProperties.put(Property.VALUE.getName(), getProperty(Property.VALUE));
                     break;
+                case PASSWORD_CREDENTIAL:
+                    resolvedAuthProperties.put(Property.CLIENT_ID.getName(), getProperty(Property.CLIENT_ID));
+                    resolvedAuthProperties.put(Property.CLIENT_SECRET.getName(), getProperty(Property.CLIENT_SECRET));
+                    resolvedAuthProperties.put(Property.USERNAME.getName(), getProperty(Property.USERNAME));
+                    resolvedAuthProperties.put(Property.PASSWORD.getName(), getProperty(Property.PASSWORD));
+                    String passwordGrantScope =
+                            propertiesMap != null ? propertiesMap.get(Property.SCOPE.getName()) : null;
+                    if (StringUtils.isNotBlank(passwordGrantScope)) {
+                        resolvedAuthProperties.put(Property.SCOPE.getName(), passwordGrantScope);
+                    }
+                    resolvedAuthProperties.put(
+                            Property.TOKEN_ENDPOINT.getName(), getProperty(Property.TOKEN_ENDPOINT));
+                    break;
                 case NONE:
                     break;
             }
@@ -224,7 +238,8 @@ public class Authentication {
         BEARER("BEARER"),
         CLIENT_CREDENTIAL("CLIENT_CREDENTIAL"),
         BASIC("BASIC"),
-        API_KEY("API_KEY");
+        API_KEY("API_KEY"),
+        PASSWORD_CREDENTIAL("PASSWORD_CREDENTIAL");
 
         private final String name;
 

--- a/components/notification-sender-config/org.wso2.carbon.identity.notification.sender.tenant.config/src/main/java/org/wso2/carbon/identity/notification/sender/tenant/config/utils/NotificationSenderSecretProcessor.java
+++ b/components/notification-sender-config/org.wso2.carbon.identity.notification.sender.tenant.config/src/main/java/org/wso2/carbon/identity/notification/sender/tenant/config/utils/NotificationSenderSecretProcessor.java
@@ -36,6 +36,7 @@ import static org.wso2.carbon.identity.notification.sender.tenant.config.Notific
 import static org.wso2.carbon.identity.notification.sender.tenant.config.NotificationSenderManagementConstants.CLIENT_SECRET;
 import static org.wso2.carbon.identity.notification.sender.tenant.config.NotificationSenderManagementConstants.INTERNAL_ACCESS_TOKEN;
 import static org.wso2.carbon.identity.notification.sender.tenant.config.NotificationSenderManagementConstants.PASSWORD;
+import static org.wso2.carbon.identity.notification.sender.tenant.config.NotificationSenderManagementConstants.PASSWORD_CREDENTIAL;
 import static org.wso2.carbon.identity.notification.sender.tenant.config.NotificationSenderManagementConstants.SECRET_PROPERTIES;
 import static org.wso2.carbon.identity.notification.sender.tenant.config.NotificationSenderManagementConstants.USERNAME;
 
@@ -104,6 +105,8 @@ public class NotificationSenderSecretProcessor {
                 INTERNAL_ACCESS_TOKEN);
         deleteSecretsForAuthType(notificationSender, BEARER, ACCESS_TOKEN_PROP);
         deleteSecretsForAuthType(notificationSender, API_KEY, API_KEY_VALUE);
+        deleteSecretsForAuthType(notificationSender, PASSWORD_CREDENTIAL, CLIENT_ID, CLIENT_SECRET, USERNAME, PASSWORD,
+                INTERNAL_ACCESS_TOKEN);
     }
 
     /**
@@ -133,6 +136,10 @@ public class NotificationSenderSecretProcessor {
            case API_KEY:
                deleteSecretsForAuthType(notificationSender, API_KEY, API_KEY_VALUE);
                break;
+           case PASSWORD_CREDENTIAL:
+               deleteSecretsForAuthType(notificationSender, PASSWORD_CREDENTIAL, CLIENT_ID, CLIENT_SECRET, USERNAME,
+                       PASSWORD, INTERNAL_ACCESS_TOKEN);
+               break;
            default:
                break;
        }
@@ -142,11 +149,13 @@ public class NotificationSenderSecretProcessor {
      * Delete internal access token secret.
      *
      * @param notificationSender Notification Sender.
+     * @param authType           Authentication Type owning the cached token (CLIENT_CREDENTIAL or PASSWORD).
      * @throws SecretManagementException If an error occurs while deleting the secret.
      */
-   public static void deleteInternalAccessTokenSecret(String notificationSender) throws SecretManagementException {
+   public static void deleteInternalAccessTokenSecret(String notificationSender, String authType)
+           throws SecretManagementException {
 
-       deleteSecretsForAuthType(notificationSender, CLIENT_CREDENTIAL, INTERNAL_ACCESS_TOKEN);
+       deleteSecretsForAuthType(notificationSender, authType, INTERNAL_ACCESS_TOKEN);
    }
 
     /**

--- a/components/notification-sender-config/org.wso2.carbon.identity.notification.sender.tenant.config/src/main/java/org/wso2/carbon/identity/notification/sender/tenant/config/utils/NotificationSenderUtils.java
+++ b/components/notification-sender-config/org.wso2.carbon.identity.notification.sender.tenant.config/src/main/java/org/wso2/carbon/identity/notification/sender/tenant/config/utils/NotificationSenderUtils.java
@@ -122,6 +122,7 @@ import static org.wso2.carbon.identity.notification.sender.tenant.config.Notific
 import static org.wso2.carbon.identity.notification.sender.tenant.config.NotificationSenderManagementConstants.MAPPING;
 import static org.wso2.carbon.identity.notification.sender.tenant.config.NotificationSenderManagementConstants.MAPPING_TYPE_KEY;
 import static org.wso2.carbon.identity.notification.sender.tenant.config.NotificationSenderManagementConstants.PASSWORD;
+import static org.wso2.carbon.identity.notification.sender.tenant.config.NotificationSenderManagementConstants.PASSWORD_CREDENTIAL;
 import static org.wso2.carbon.identity.notification.sender.tenant.config.NotificationSenderManagementConstants.PLACEHOLDER_IDENTIFIER;
 import static org.wso2.carbon.identity.notification.sender.tenant.config.NotificationSenderManagementConstants.PROCESSING_KEY;
 import static org.wso2.carbon.identity.notification.sender.tenant.config.NotificationSenderManagementConstants.PROPERTIES_TO_SKIP_AT_ADAPTER_CONFIG;
@@ -504,24 +505,29 @@ public class NotificationSenderUtils {
         }
 
         try {
+            boolean isPasswordGrant = PASSWORD_CREDENTIAL.equalsIgnoreCase(emailSender.getAuthType());
             if (StringUtils.isNotEmpty(emailSender.getAuthType())) {
                 adapterProperties.put(HTTP_AUTH_TYPE_PROPERTY, emailSender.getAuthType());
             }
             if (StringUtils.isNotEmpty(emailSender.getProperties().get(USERNAME))) {
-                adapterProperties.put(HTTP_USERNAME_PROPERTY, encryptCredential(EMAIL_PROVIDER, BASIC, USERNAME,
+                adapterProperties.put(HTTP_USERNAME_PROPERTY, encryptCredential(EMAIL_PROVIDER,
+                        isPasswordGrant ? PASSWORD_CREDENTIAL : BASIC, USERNAME,
                         emailSender.getProperties().get(USERNAME)));
             }
             if (StringUtils.isNotEmpty(emailSender.getProperties().get(PASSWORD))) {
-                adapterProperties.put(HTTP_PASSWORD_PROPERTY, encryptCredential(EMAIL_PROVIDER, BASIC, PASSWORD,
+                adapterProperties.put(HTTP_PASSWORD_PROPERTY, encryptCredential(EMAIL_PROVIDER,
+                        isPasswordGrant ? PASSWORD_CREDENTIAL : BASIC, PASSWORD,
                         emailSender.getProperties().get(PASSWORD)));
             }
             if (StringUtils.isNotEmpty(emailSender.getProperties().get(CLIENT_ID))) {
-                adapterProperties.put(HTTP_CLIENT_ID_PROPERTY, encryptCredential(EMAIL_PROVIDER, CLIENT_CREDENTIAL,
-                        CLIENT_ID, emailSender.getProperties().get(CLIENT_ID)));
+                adapterProperties.put(HTTP_CLIENT_ID_PROPERTY, encryptCredential(EMAIL_PROVIDER,
+                        isPasswordGrant ? PASSWORD_CREDENTIAL : CLIENT_CREDENTIAL, CLIENT_ID,
+                        emailSender.getProperties().get(CLIENT_ID)));
             }
             if (StringUtils.isNotEmpty(emailSender.getProperties().get(CLIENT_SECRET))) {
-                adapterProperties.put(HTTP_CLIENT_SECRET_PROPERTY, encryptCredential(EMAIL_PROVIDER, CLIENT_CREDENTIAL,
-                        CLIENT_SECRET, emailSender.getProperties().get(CLIENT_SECRET)));
+                adapterProperties.put(HTTP_CLIENT_SECRET_PROPERTY, encryptCredential(EMAIL_PROVIDER,
+                        isPasswordGrant ? PASSWORD_CREDENTIAL : CLIENT_CREDENTIAL, CLIENT_SECRET,
+                        emailSender.getProperties().get(CLIENT_SECRET)));
             }
             if (StringUtils.isNotEmpty(emailSender.getProperties().get(TOKEN_ENDPOINT))) {
                 adapterProperties.put(HTTP_TOKEN_ENDPOINT_PROPERTY, emailSender.getProperties().get(TOKEN_ENDPOINT));

--- a/components/notification-sender-config/org.wso2.carbon.identity.notification.sender.tenant.config/src/main/java/org/wso2/carbon/identity/notification/sender/tenant/config/utils/TokenManager.java
+++ b/components/notification-sender-config/org.wso2.carbon.identity.notification.sender.tenant.config/src/main/java/org/wso2/carbon/identity/notification/sender/tenant/config/utils/TokenManager.java
@@ -108,7 +108,8 @@ public class TokenManager {
     private TokenRequestContext buildTokenRequestContext(Authentication authentication)
             throws NotificationSenderManagementServerException {
 
-        if (authentication.getType() != Authentication.Type.CLIENT_CREDENTIAL) {
+        if (authentication.getType() != Authentication.Type.CLIENT_CREDENTIAL
+                && authentication.getType() != Authentication.Type.PASSWORD_CREDENTIAL) {
             throw new NotificationSenderManagementServerException(
                     ErrorMessage.ERROR_CODE_ERROR_UNSUPPORTED_AUTH_TYPE_FOR_TOKEN_RETRIEVAL, null);
         }
@@ -125,8 +126,22 @@ public class TokenManager {
             if (StringUtils.isNotBlank(scope)) {
                 grantTypeProperties.put(GrantContext.Property.SCOPE.getName(), scope);
             }
+
+            GrantContext.GrantType grantType;
+            if (authentication.getType() == Authentication.Type.PASSWORD_CREDENTIAL) {
+                grantType = GrantContext.GrantType.PASSWORD;
+                grantTypeProperties.put(
+                        GrantContext.Property.USERNAME.getName(),
+                        authentication.getProperty(Authentication.Property.USERNAME.getName()));
+                grantTypeProperties.put(
+                        GrantContext.Property.PASSWORD.getName(),
+                        authentication.getProperty(Authentication.Property.PASSWORD.getName()));
+            } else {
+                grantType = GrantContext.GrantType.CLIENT_CREDENTIAL;
+            }
+
             GrantContext grantContext = new GrantContext.Builder()
-                    .grantType(GrantContext.GrantType.CLIENT_CREDENTIAL)
+                    .grantType(grantType)
                     .properties(grantTypeProperties)
                     .build();
 

--- a/components/notification-sender-config/org.wso2.carbon.identity.notification.sender.tenant.config/src/test/java/org/wso2/carbon/identity/notification/sender/tenant/config/dto/AuthenticationTest.java
+++ b/components/notification-sender-config/org.wso2.carbon.identity.notification.sender.tenant.config/src/test/java/org/wso2/carbon/identity/notification/sender/tenant/config/dto/AuthenticationTest.java
@@ -91,6 +91,38 @@ public class AuthenticationTest {
     }
 
     @Test
+    public void testAuthenticationBuilderWithPasswordGrant() throws Exception {
+
+        authProperties.put(Property.CLIENT_ID.getName(), "test-client-id");
+        authProperties.put(Property.CLIENT_SECRET.getName(), "test-client-secret");
+        authProperties.put(Property.USERNAME.getName(), "test-username");
+        authProperties.put(Property.PASSWORD.getName(), "test-password");
+        authProperties.put(Property.SCOPE.getName(), "test-scope");
+        authProperties.put(Property.TOKEN_ENDPOINT.getName(), "https://test.com/token");
+
+        Authentication auth = new Authentication.AuthenticationBuilder("PASSWORD_CREDENTIAL", authProperties).build();
+
+        Assert.assertNotNull(auth);
+        Assert.assertEquals(auth.getType(), Type.PASSWORD_CREDENTIAL);
+        Assert.assertEquals(auth.getProperty(Property.CLIENT_ID.getName()), "test-client-id");
+        Assert.assertEquals(auth.getProperty(Property.CLIENT_SECRET.getName()), "test-client-secret");
+        Assert.assertEquals(auth.getProperty(Property.USERNAME.getName()), "test-username");
+        Assert.assertEquals(auth.getProperty(Property.PASSWORD.getName()), "test-password");
+        Assert.assertEquals(auth.getProperty(Property.SCOPE.getName()), "test-scope");
+        Assert.assertEquals(auth.getProperty(Property.TOKEN_ENDPOINT.getName()), "https://test.com/token");
+    }
+
+    @Test(expectedExceptions = NotificationSenderManagementClientException.class)
+    public void testAuthenticationBuilderWithPasswordGrantMissingProperty() throws Exception {
+
+        authProperties.put(Property.CLIENT_ID.getName(), "test-client-id");
+        authProperties.put(Property.CLIENT_SECRET.getName(), "test-client-secret");
+        authProperties.put(Property.TOKEN_ENDPOINT.getName(), "https://test.com/token");
+
+        new Authentication.AuthenticationBuilder("PASSWORD_CREDENTIAL", authProperties).build();
+    }
+
+    @Test
     public void testAuthenticationBuilderWithApiKey() throws Exception {
 
         authProperties.put(Property.HEADER.getName(), "X-API-KEY");

--- a/components/notification-sender-config/org.wso2.carbon.identity.notification.sender.tenant.config/src/test/java/org/wso2/carbon/identity/notification/sender/tenant/config/utils/TokenManagerTest.java
+++ b/components/notification-sender-config/org.wso2.carbon.identity.notification.sender.tenant.config/src/test/java/org/wso2/carbon/identity/notification/sender/tenant/config/utils/TokenManagerTest.java
@@ -67,6 +67,23 @@ public class TokenManagerTest {
     }
 
     @Test
+    public void testAuthenticationWithPasswordGrant() throws Exception {
+        authProperties.put(Authentication.Property.CLIENT_ID.getName(), "test-client-id");
+        authProperties.put(Authentication.Property.CLIENT_SECRET.getName(), "test-client-secret");
+        authProperties.put(Authentication.Property.USERNAME.getName(), "test-username");
+        authProperties.put(Authentication.Property.PASSWORD.getName(), "test-password");
+        authProperties.put(Authentication.Property.SCOPE.getName(), "test-scope");
+        authProperties.put(Authentication.Property.TOKEN_ENDPOINT.getName(), "https://test.com/token");
+
+        Authentication auth = new Authentication.AuthenticationBuilder("PASSWORD_CREDENTIAL", authProperties).build();
+
+        Assert.assertNotNull(auth);
+        Assert.assertEquals(auth.getType(), Authentication.Type.PASSWORD_CREDENTIAL);
+        Assert.assertEquals(auth.getProperty(Authentication.Property.USERNAME.getName()), "test-username");
+        Assert.assertEquals(auth.getProperty(Authentication.Property.PASSWORD.getName()), "test-password");
+    }
+
+    @Test
     public void testAuthenticationWithBasicType() throws Exception {
         authProperties.put(Authentication.Property.USERNAME.getName(), "testuser");
         authProperties.put(Authentication.Property.PASSWORD.getName(), "testpass");


### PR DESCRIPTION
## Purpose

Add OAuth 2.0 Resource Owner Password Credentials (`PASSWORD_CREDENTIAL`) as a supported authentication type for HTTP-based Email and SMS Notification Providers, alongside the existing NONE, BASIC, BEARER, API_KEY, and CLIENT_CREDENTIAL options.

This is needed for downstream notification services that validate the `sub` claim of the presented access token against a specific service-account user — something the Client Credentials grant cannot provide, since it produces a token bound to the application/client rather than a resource owner.

The password-grant token exchange itself is not new: it reuses `GrantContext.GrantType.PASSWORD` in the shared `carbon-identity-framework` External Token Acquirer Service, which already backs the equivalent `PASSWORD_CREDENTIAL` support shipped for Actions and Custom Authenticators (see wso2/carbon-identity-framework#8079 and #8088).

## Summary of changes

* `dto/Authentication.java` — adds `Type.PASSWORD_CREDENTIAL`; resolves `clientId`, `clientSecret`, `username`, `password`, `tokenEndpoint`, and optional `scope`; builds the Bearer header from the cached internal access token, mirroring `CLIENT_CREDENTIAL`.
* `utils/TokenManager.java` — extends `buildTokenRequestContext()` to build a `GrantContext` with `GrantType.PASSWORD` when the auth type is `PASSWORD_CREDENTIAL`.
* `NotificationSenderManagementServiceImpl.java` — email-side property validation, auth-type-change secret cleanup, and the SMS 401-retry path (`rebuildAuthHeaderWithNewToken`) all recognize `PASSWORD_CREDENTIAL`.
* `NotificationSenderSecretProcessor.java` / `NotificationSenderUtils.java` — Password Credential secrets are tagged under a distinct namespace so they don't collide with `BASIC` or `CLIENT_CREDENTIAL` secrets when an admin switches auth types.
* Unit tests added to `AuthenticationTest.java` and `TokenManagerTest.java` covering the new grant type.

## Test plan

- [x] `mvn test` on the `notification-sender-config` module — 144/144 tests pass (141 existing + 3 new)
- [x] Checkstyle clean
- [ ] Manual verification against a running pack (pending)

## Related work

- Companion changes in `identity-api-server` (REST API / OpenAPI spec) and `identity-apps` (Console UI) are submitted separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added password-credential authentication for email and SMS notification senders.
  - Supports username, password, client credentials, optional scope, and token endpoint configuration.
  - Automatically requests and refreshes access tokens using the password grant.
  - Securely stores and removes password-credential secrets.

- **Tests**
  - Added coverage for valid password authentication configurations and missing required properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->